### PR TITLE
[Refactor] #14 - 중복되는 색상 이름 수정

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Color.swift
+++ b/Projects/Shared/DesignSystem/Sources/Color.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 public extension Color {
-    static let primary = MandamongColor.primary.color
-    static let accentColor = MandamongColor.primary.color
-    static let background = MandamongColor.background.color
+    static let mandamongPrimary = MandamongColor.primary.color
+    static let mandamongAccentColor = MandamongColor.primary.color
+    static let mandamongBackground = MandamongColor.background.color
     
     static func hex(_ hex: UInt, alpha: Double = 1) -> Self {
         .init(


### PR DESCRIPTION
# 📄 작업 내용
- SwiftUI.Color에 이미 정의되어 있던 프로퍼티명을 사용하지 않도록 하여 컴파일 에러 발생 예방

## 🔗 연결된 이슈
- Resolved: #14 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터링
  - 앱 전반의 색상 토큰 명칭을 일관되게 정리했습니다. 기존 primary, accent, background를 mandamong* 접두어로 통일해 가독성과 유지보수성을 개선했습니다.
  - 실제 색상 값과 테마 매핑은 동일하므로 화면상의 시각적 변화는 없습니다.
  - 외부에서 색상을 참조하던 경우, 새로운 명칭으로 대체가 필요합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->