### PR TITLE
[Setting] DeploymentTargets 정립

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .app,
             bundleId: "com.mandamong.app",
+            deploymentTargets: .iOS("17.0"),
             infoPlist: .default,
             sources: ["Sources/**"],
             dependencies: [

--- a/Projects/LocalDB/Project.swift
+++ b/Projects/LocalDB/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.localdb",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 

--- a/Projects/Login/LoginData/Project.swift
+++ b/Projects/Login/LoginData/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.logindata",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "Network", path: "../../Network"),

--- a/Projects/Login/LoginDomain/Project.swift
+++ b/Projects/Login/LoginDomain/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.logindomain",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "LoginData", path: "../LoginData"),

--- a/Projects/Login/LoginFeature/Project.swift
+++ b/Projects/Login/LoginFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.loginfeature",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "LoginDomain", path: "../LoginDomain"),

--- a/Projects/Mandarat/MandaratData/Project.swift
+++ b/Projects/Mandarat/MandaratData/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.mandaratdata",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "Network", path: "../../Network"),

--- a/Projects/Mandarat/MandaratDomain/Project.swift
+++ b/Projects/Mandarat/MandaratDomain/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.mandaratdomain",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "MandaratData", path: "../MandaratData"),

--- a/Projects/Mandarat/MandaratFeature/Project.swift
+++ b/Projects/Mandarat/MandaratFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.mandaratfeature",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .project(target: "MandaratDomain", path: "../MandaratDomain"),

--- a/Projects/Network/Project.swift
+++ b/Projects/Network/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.network",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Sources/**"],
             dependencies: [
                 .external(name: "Alamofire")

--- a/Projects/Shared/Project.swift
+++ b/Projects/Shared/Project.swift
@@ -8,6 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.designsystem",
+            deploymentTargets: .iOS("17.0"),
             sources: ["DesignSystem/Sources/**"],
             resources: ["DesignSystem/Resources/**"]
         ),
@@ -16,6 +17,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.mandamong.utils",
+            deploymentTargets: .iOS("17.0"),
             sources: ["Utils/Sources/**"]
         )
     ]

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a3d1c8247c7f57a1f28d97c4bbadbe96e4c1f150eebc449e5bf9500453a9ddc7",
+  "originHash" : "6140a1abf0cff6b66d03ed1e628e15fbf56f805ce6551de786e69f2933c38aca",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "acd9bb8a7cf6e36a89d81a432c2e8eb3b1bb3771",
-        "version" : "1.22.2"
+        "revision" : "2d60d4082dfb4978974307acf0f00dfa20e5f621",
+        "version" : "1.22.3"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -16,6 +16,6 @@ let package = Package(
     name: "Projects",
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", .upToNextMajor(from: "1.22.2"))
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", .upToNextMajor(from: "1.22.3"))
     ]
 )


### PR DESCRIPTION
## 📄 작업 내용
- 빌드 타겟을 iOS 17.0+ 으로 설정했습니다.

## 👀 리뷰어에게 전달할 사항
* 라이브 코딩으로 시연했습니다.

## 🔗 연결된 이슈
- Resolved: #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 주요 변경
  - 앱의 최소 지원 iOS 버전을 iOS 17로 상향 조정했습니다. iOS 17 미만 기기에서는 최신 버전 설치 및 실행이 불가합니다.

- Chores
  - 프로젝트 전반의 타깃 설정을 iOS 17 기준으로 정렬했습니다.

- Dependencies
  - 외부 라이브러리(Composable Architecture) 소버전 업데이트(1.22.2 → 1.22.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->