### PR TITLE
[Feat] Login/Register View+Feature (WIP)

### DIFF
--- a/Projects/Login/LoginFeature/Sources/AuthView/AuthFeature.swift
+++ b/Projects/Login/LoginFeature/Sources/AuthView/AuthFeature.swift
@@ -1,0 +1,53 @@
+//
+//  AuthFeature.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/4/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct AuthFeature {
+    @ObservableState
+    struct State: Equatable {
+        enum AuthStep {
+            case login, register, adjustPassword
+        }
+        
+        var currentStep: AuthStep = .login
+        var loginFeatureState:  LoginFeature.State = .init()
+        var registerFeatureState: RegisterFeature.State = .init()
+    }
+    
+    @CasePathable
+    enum Action {
+        case loginFeatureAction(LoginFeature.Action)
+        case registerFeatureAction(RegisterFeature.Action)
+    }
+    
+    var body: some Reducer<State, Action> {
+        Scope(state: \.loginFeatureState, action: \.loginFeatureAction) { LoginFeature() }
+        Scope(state: \.registerFeatureState, action: \.registerFeatureAction) { RegisterFeature() }
+        
+        Reduce { state, action in
+            switch action {
+            case .loginFeatureAction(.delegate(.switchToRegister)):
+                state.currentStep = .register
+                return .none
+                
+            case .loginFeatureAction(.delegate(.switchToAdjustPassword)):
+                state.currentStep = .adjustPassword
+                return .none
+                
+            case .registerFeatureAction(.delegate(.switchToLogin)):
+                state.currentStep = .login
+                return .none
+                
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Login/LoginFeature/Sources/AuthView/AuthView.swift
+++ b/Projects/Login/LoginFeature/Sources/AuthView/AuthView.swift
@@ -1,0 +1,32 @@
+//
+//  AuthView.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/4/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct AuthView: View {
+    let store: StoreOf<AuthFeature>
+    
+    var body: some View {
+        ZStack {
+            switch store.currentStep {
+            case .login:
+                LoginView(store: store.scope(state: \.loginFeatureState, action: \.loginFeatureAction))
+                
+            case .register:
+                RegisterView(store: store.scope(state: \.registerFeatureState, action: \.registerFeatureAction))
+                
+            case .adjustPassword:
+                Text("비밀번호 찾기")
+            }
+        }
+    }
+}
+
+#Preview {
+    AuthView(store: .init(initialState: AuthFeature.State(), reducer: { AuthFeature() }))
+}

--- a/Projects/Login/LoginFeature/Sources/LoginView/LoginFeature.swift
+++ b/Projects/Login/LoginFeature/Sources/LoginView/LoginFeature.swift
@@ -1,0 +1,65 @@
+//
+//  LoginFeature.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/4/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct LoginFeature {
+    @ObservableState
+    struct State: Equatable {
+        enum Field: Hashable { case email, password }
+        
+        var email: String = ""
+        var password: String = ""
+        var focusedField: Field?
+    }
+    
+    @CasePathable
+    enum Action: BindableAction {
+        enum ViewAction {
+            case loginButtonTapped
+            case registerButtonTapped
+            case adjustPasswordButtonTapped
+        }
+        
+        enum DelegateAction {
+            case switchToRegister
+            case switchToAdjustPassword
+        }
+        
+        case view(ViewAction)
+        case binding(BindingAction<State>)
+        case delegate(DelegateAction)
+    }
+    
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .view(.loginButtonTapped):
+                return .none
+                
+            case .view(.registerButtonTapped):
+                return .send(.delegate(.switchToRegister))
+                
+            case .view(.adjustPasswordButtonTapped):
+                return .send(.delegate(.switchToAdjustPassword))
+                
+            case .binding(\.email):
+                return .none
+                
+            case .binding(\.password):
+                return .none
+            
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Login/LoginFeature/Sources/LoginView/LoginView.swift
+++ b/Projects/Login/LoginFeature/Sources/LoginView/LoginView.swift
@@ -1,0 +1,70 @@
+//
+//  LoginView.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/3/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct LoginView: View {
+    @Bindable var store: StoreOf<LoginFeature>
+    @FocusState private var focusState: LoginFeature.State.Field?
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(Mandamong.Strings.Login.title)
+                .mandamongFont(.primary)
+            
+            Text(Mandamong.Strings.Login.subtitle)
+                .mandamongFont(.caption)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Login.emailPlaceholder, text: $store.email, focused: $store.focusedField, equals: .email)
+                .focused($focusState, equals: .email)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Login.passwordPlaceholder, text: $store.password, focused: $store.focusedField, equals: .password, isSecure: true)
+                .focused($focusState, equals: .password)
+            
+            Button {
+                store.send(.view(.loginButtonTapped))
+            } label: {
+                Text(Mandamong.Strings.Login.loginButtonTitle)
+                    .mandamongFont(.primary)
+                    .foregroundStyle(.white)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
+                    .background {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(.mandamongPrimary)
+                    }
+            }
+            
+            HStack {
+                Button {
+                    store.send(.view(.registerButtonTapped))
+                } label: {
+                    Text(Mandamong.Strings.Login.switchToRegisterButtonTitle)
+                        .underline()
+                }
+                
+                Spacer()
+                
+                Button {
+                    store.send(.view(.adjustPasswordButtonTapped))
+                } label: {
+                    Text(Mandamong.Strings.Login.switchToAdjustPasswordButtonTitle)
+                        .underline()
+                }
+            }
+        }
+        .onChange(of: store.focusedField) { _, newValue in
+            focusState = newValue
+        }
+        .onChange(of: focusState) { _, newValue in
+            store.send(.binding(.set(\.focusedField, newValue)))
+        }
+        .padding()
+    }
+}

--- a/Projects/Login/LoginFeature/Sources/RegisterView/RegisterFeature.swift
+++ b/Projects/Login/LoginFeature/Sources/RegisterView/RegisterFeature.swift
@@ -1,0 +1,56 @@
+//
+//  RegisterFeature.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/4/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct RegisterFeature {
+    @ObservableState
+    struct State: Equatable {
+        enum Field: Hashable { case email, nickname, password, passwordConfirmation }
+        
+        var email: String = ""
+        var nickname: String = ""
+        var password: String = ""
+        var passwordConfirmation: String = ""
+        var focusedField: Field?
+    }
+    
+    @CasePathable
+    enum Action: BindableAction {
+        enum ViewAction {
+            case registerButtonTapped
+            case loginButtonTapped
+        }
+        
+        enum DelegateAction {
+            case switchToLogin
+        }
+        
+        case view(ViewAction)
+        case binding(BindingAction<State>)
+        case delegate(DelegateAction)
+    }
+    
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .view(.registerButtonTapped):
+                return .none
+                
+            case .view(.loginButtonTapped):
+                return .send(.delegate(.switchToLogin))
+                
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Login/LoginFeature/Sources/RegisterView/RegisterView.swift
+++ b/Projects/Login/LoginFeature/Sources/RegisterView/RegisterView.swift
@@ -1,0 +1,69 @@
+//
+//  RegisterView.swift
+//  LoginFeature
+//
+//  Created by SwainYun on 10/4/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct RegisterView: View {
+    @Bindable var store: StoreOf<RegisterFeature>
+    @FocusState private var focusState: RegisterFeature.State.Field?
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(Mandamong.Strings.Register.title)
+                .mandamongFont(.primary)
+            
+            Text(Mandamong.Strings.Register.subtitle)
+                .mandamongFont(.caption)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Register.emailPlaceholder, text: $store.email, focused: $store.focusedField, equals: .email)
+                .focused($focusState, equals: .email)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Register.nicknamePlaceholder, text: $store.nickname, focused: $store.focusedField, equals: .nickname)
+                .focused($focusState, equals: .nickname)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Register.passwordPlaceholder, text: $store.password, focused: $store.focusedField, equals: .password, isSecure: true)
+                .focused($focusState, equals: .password)
+            
+            FloatingTitleTextField(title: Mandamong.Strings.Register.passwordConfirmationPlaceholder, text: $store.passwordConfirmation, focused: $store.focusedField, equals: .passwordConfirmation, isSecure: true)
+                .focused($focusState, equals: .passwordConfirmation)
+            
+            Button {
+                store.send(.view(.registerButtonTapped))
+            } label: {
+                Text(Mandamong.Strings.Register.registerButtonTitle)
+                    .mandamongFont(.primary)
+                    .foregroundStyle(.white)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
+                    .background {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(.mandamongPrimary)
+                    }
+            }
+            
+            Button {
+                store.send(.view(.loginButtonTapped))
+            } label: {
+                Text(Mandamong.Strings.Register.switchToLoginButtonTitle)
+                    .underline()
+            }
+            .onChange(of: store.focusedField) { _, newValue in
+                focusState = newValue
+            }
+            .onChange(of: focusState) { _, newValue in
+                store.send(.binding(.set(\.focusedField, newValue)))
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    RegisterView(store: .init(initialState: RegisterFeature.State(), reducer: { RegisterFeature() }))
+}

--- a/Projects/Login/LoginFeature/Sources/RegisterView/RegisterView.swift
+++ b/Projects/Login/LoginFeature/Sources/RegisterView/RegisterView.swift
@@ -53,12 +53,12 @@ struct RegisterView: View {
                 Text(Mandamong.Strings.Register.switchToLoginButtonTitle)
                     .underline()
             }
-            .onChange(of: store.focusedField) { _, newValue in
-                focusState = newValue
-            }
-            .onChange(of: focusState) { _, newValue in
-                store.send(.binding(.set(\.focusedField, newValue)))
-            }
+        }
+        .onChange(of: store.focusedField) { _, newValue in
+            focusState = newValue
+        }
+        .onChange(of: focusState) { _, newValue in
+            store.send(.binding(.set(\.focusedField, newValue)))
         }
         .padding()
     }

--- a/Projects/Shared/DesignSystem/Sources/Color.swift
+++ b/Projects/Shared/DesignSystem/Sources/Color.swift
@@ -7,10 +7,12 @@
 
 import SwiftUI
 
-public extension Color {
-    static let mandamongPrimary = MandamongColor.primary.color
-    static let mandamongAccentColor = MandamongColor.primary.color
-    static let mandamongBackground = MandamongColor.background.color
+public extension ShapeStyle where Self == Color {
+    static var mandamongPrimary: Color { MandamongColor.primary.color }
+    static var mandamongAccentColor: Color { MandamongColor.primary.color }
+    static var mandamongBackground: Color { MandamongColor.background.color }
+    static var mandamongSecondary: Color { MandamongColor.secondary.color }
+    
     
     static func hex(_ hex: UInt, alpha: Double = 1) -> Self {
         .init(
@@ -28,6 +30,7 @@ public extension Color {
 public enum MandamongColor: UInt {
     case primary = 0x7122FF
     case background = 0xFAFCFE
+    case secondary = 0xBBBBBB
     
     fileprivate var color: Color { .hex(self.rawValue) }
 }

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -8,9 +8,7 @@
 import Foundation
 
 /// 앱  최상위 네임스페이스
-public enum Mandamong {
-    
-}
+public enum Mandamong { }
 
 // MARK: - Mandamong + Strings
 extension Mandamong {
@@ -38,8 +36,6 @@ extension Mandamong {
             public static let registerButtonTitle: String = "회원가입"
             public static let switchToLoginButtonTitle: String = "이미 계정이 있으신가요? 로그인"
         }
-        
-        
     }
 }
 

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -1,0 +1,52 @@
+//
+//  Mandamong.swift
+//  DesignSystem
+//
+//  Created by SwainYun on 10/6/25.
+//
+
+import Foundation
+
+/// 앱  최상위 네임스페이스
+public enum Mandamong {
+    
+}
+
+// MARK: - Mandamong + Strings
+extension Mandamong {
+    /// 문자열 리터럴
+    public enum Strings {
+        /// 로그인 화면 관련 리터럴
+        public enum Login {
+            public static let title: String = "로그인"
+            public static let subtitle: String = "계정에 로그인하고 만다르트를 만들어보세요."
+            public static let emailPlaceholder: String = "이메일"
+            public static let passwordPlaceholder: String = "비밀번호"
+            public static let loginButtonTitle: String = "로그인"
+            public static let switchToRegisterButtonTitle: String = "회원가입"
+            public static let switchToAdjustPasswordButtonTitle: String = "비밀번호 찾기"
+        }
+        
+        /// 회원가입 화면 관련 리터럴
+        public enum Register {
+            public static let title: String = "회원가입"
+            public static let subtitle: String = "계정을 생성하고 만다르트를 만들어보세요."
+            public static let emailPlaceholder: String = "이메일"
+            public static let nicknamePlaceholder: String = "닉네임"
+            public static let passwordPlaceholder: String = "비밀번호"
+            public static let passwordConfirmationPlaceholder: String = "비밀번호 재입력"
+            public static let registerButtonTitle: String = "회원가입"
+            public static let switchToLoginButtonTitle: String = "이미 계정이 있으신가요? 로그인"
+        }
+        
+        
+    }
+}
+
+// MARK: - Mandamong - Constants
+extension Mandamong {
+    /// 상수값
+    public enum Constants {
+//        public static let defaultCornerRadius: CGFloat = 8
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/ReusableComponents/FloatingTitleTextField.swift
+++ b/Projects/Shared/DesignSystem/Sources/ReusableComponents/FloatingTitleTextField.swift
@@ -1,0 +1,55 @@
+//
+//  FloatingTitleTextField.swift
+//  DesignSystem
+//
+//  Created by SwainYun on 10/3/25.
+//
+
+import SwiftUI
+
+public struct FloatingTitleTextField<FocusType: Hashable>: View {
+    @Binding var text: String
+    @Binding var focused: FocusType?
+    
+    let title: String
+    var isSecure: Bool
+    private let focusType: FocusType
+    
+    private var isFocused: Bool { focused == focusType }
+    private var isTitleFloating: Bool { text.isEmpty == false || isFocused }
+    
+    public init(title: String, text: Binding<String>, focused: Binding<FocusType?>, equals focusType: FocusType, isSecure: Bool = false) {
+        self.title = title
+        self._text = text
+        self._focused = focused
+        self.focusType = focusType
+        self.isSecure = isSecure
+    }
+    
+    public var body: some View {
+        ZStack(alignment: .leading) {
+            Group {
+                if isSecure {
+                    SecureField("", text: $text)
+                } else {
+                    TextField("", text: $text)
+                }
+            }
+            .padding()
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(isFocused ? .mandamongPrimary : .mandamongSecondary, lineWidth: 1)
+            }
+            
+            Text(title)
+                .mandamongFont(isTitleFloating ? .caption : .secondary)
+                .padding(.horizontal, isTitleFloating ? 4 : .zero)
+                .background(.white)
+                .padding(.leading, 12)
+                .offset(y: isTitleFloating ? -30 : .zero)
+                .onTapGesture { focused = focusType }
+        }
+        .animation(.spring(duration: 0.3), value: isTitleFloating)
+        .animation(.spring(duration: 0.3), value: isFocused)
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용
- 반복되는 UI Component 정의: `FloatingTitleTextField`
- 로그인 화면 추가: `AuthView` + `AuthFeature`
- 회원가입 화면 추가: `RegisterView` + `RegisterFeature`
- 상위 컨테이너(진입점 역할) 화면 추가: `AuthView` + `AuthFeature`

## 👀 리뷰어에게 전달할 사항
**작업 전 논의한 사항**
1. TCA를 이용한 라우팅 방식 협의해 보아야 함. (컨테이너 역할, TCACoordinator, Reducer 합성 및 분리에 따른 설계 방침 등)
2. 리터럴 중앙일원화 개념을 듣고 비슷하게 따라해보았는데 적절한지 검토 필요.
3. 작업 목표 분배 (OAuth2.0 및 설정파일 공유 등)

**참고사항**
1. 현재 모든 리듀서의 Effect 반환은 없습니다. (`.none`) API 기능 연결 준비를 마치고 비즈니스로직이 도출되면 추후 완성해야 합니다.

## 🔗 연결된 이슈
- Resolved: #33 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 인증 흐름 통합 화면 추가: 로그인/회원가입/비밀번호 조정 단계 전환 지원.
  - 로그인 화면 추가: 이메일/비밀번호 입력, 로그인 버튼, 회원가입·비밀번호 조정 이동 동작.
  - 회원가입 화면 추가: 이메일/닉네임/비밀번호/비밀번호 확인 입력 및 로그인으로 전환.
  - 재사용 가능한 플로팅 타이틀 텍스트 필드 컴포넌트 도입.

- 스타일
  - 컬러 토큰 확장 및 보조 색상 추가로 버튼·입력 필드 시각 일관성 개선.

- 기타
  - 인증 관련 UI 텍스트 리소스 정리 및 중앙화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->