### PR TITLE
[Setting] 프로젝트 공유 파일 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+Tuist/Configs

--- a/Projects/App/App.entitlements
+++ b/Projects/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -15,6 +15,7 @@ let project = Project(
                 ])
             ]),
             sources: ["Sources/**"],
+            entitlements: .file(path: .relativeToRoot("Projects/App/App.entitlements")),
             dependencies: [
                 .project(target: "LoginFeature", path: "../Login/LoginFeature"),
                 .project(target: "MandaratFeature", path: "../Mandarat/MandaratFeature"),

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -21,15 +21,11 @@ let project = Project(
                 .project(target: "MandaratFeature", path: "../Mandarat/MandaratFeature"),
             ],
             settings: .settings(
-                base: [
-                    "CODE_SIGN_STYLE": "Manual",
-                    "DEVELOPMENT_TEAM": "P85DW78LYM",
-                ],
                 configurations: [
-                    .debug(name: .debug, settings: [
-                        "CODE_SIGN_IDENTITY": "Apple Development",
-                        "PROVISIONING_PROFILE_SPECIFIER": "debug-mandamong",
-                    ])
+                    .debug(
+                        name: .debug,
+                        xcconfig: .relativeToRoot("Tuist/Configs/Debug.xcconfig")
+                    )
                 ]
             )
         )

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -19,7 +19,19 @@ let project = Project(
             dependencies: [
                 .project(target: "LoginFeature", path: "../Login/LoginFeature"),
                 .project(target: "MandaratFeature", path: "../Mandarat/MandaratFeature"),
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    "CODE_SIGN_STYLE": "Manual",
+                    "DEVELOPMENT_TEAM": "P85DW78LYM",
+                ],
+                configurations: [
+                    .debug(name: .debug, settings: [
+                        "CODE_SIGN_IDENTITY": "Apple Development",
+                        "PROVISIONING_PROFILE_SPECIFIER": "debug-mandamong",
+                    ])
+                ]
+            )
         )
     ]
 )


### PR DESCRIPTION
<!--
[Prefix] 작업 설명
예시 : [Feat] 마이페이지 뷰 구현

## Rules
1. issue를 작성한다.
2. `prefix/#이슈번호-내용`으로 브랜치를 생성한다.
    - 이슈 내용이 로그인 로직 수정이라면,,
        - `refactor/#112-login-logic`
3. 해당 브랜치에서 작업
4. develop으로 PR 생성
5. develop으로 merge
6. merge 후, 기존 브랜치 삭제
-->

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 공유 파일 (인증서 등)을 위한 xcconfig 파일을 작성하고, 이를 가져오도록 하였습니다.

## 🔗 연결된 이슈
- Resolved: #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Apple 로그인 권한(Entitlements)을 추가해 기능 사용이 가능해졌습니다.

- 작업
  - 프로젝트 설정에 권한 파일을 연결하여 배포/빌드 구성의 일관성을 개선했습니다.
  - 디버그 빌드 설정을 정리하고 별도 구성 파일을 연동했습니다.
  - 버전 관리에서 Tuist 관련 추가 구성 파일을 무시하도록 범위를 확장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->