### PR TITLE
[Feat] Make Mandarat Chart Component

### DIFF
--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -8,31 +8,93 @@
 import Foundation
 
 /// 목표별 행동 아이디어
-struct ActionIdea: Identifiable {
-    let id: UInt
-    var action: String
-    var isCompleted: Bool
+public struct ActionIdea: Identifiable, Equatable, Hashable {
+    public let id: UInt
+    public var action: String
+    public var isCompleted: Bool
+    
+    public init(id: UInt, action: String, isCompleted: Bool) {
+        self.id = id
+        self.action = action
+        self.isCompleted = isCompleted
+    }
 }
 
 /// 핵심 주제별 목표
-struct Objective: Identifiable {
-    let id:  UInt
-    var content: String
-    var actionItems: [ActionIdea]
+public struct Objective: Identifiable, Equatable, Hashable {
+    public let id:  UInt
+    public var content: String
+    public var actionItems: [ActionIdea]
+    
+    public init(id: UInt, content: String, actionItems: [ActionIdea]) {
+        self.id = id
+        self.content = content
+        self.actionItems = actionItems
+    }
 }
 
 /// 핵심 주제
-struct Subject: Identifiable {
-    let id: UInt
-    var content: String
-    var isCompleted: Bool
+public struct Subject: Identifiable, Equatable, Hashable {
+    public let id: UInt
+    public var content: String
+    public var isCompleted: Bool
+    
+    public init(id: UInt, content: String, isCompleted: Bool) {
+        self.id = id
+        self.content = content
+        self.isCompleted = isCompleted
+    }
 }
 
 /// 만다라트 차트
-struct Mandarat: Identifiable {
-    let id: UInt
-    var title: String = ""
-    var subject: Subject
-    var objectives: [Objective]
-    let createdAt: Date = .now
+public struct Mandarat: Identifiable, Equatable {
+    public let id: UInt
+    public var title: String
+    public var subject: Subject
+    public var objectives: [Objective]
+    public let createdAt: Date
+    
+    public init(id: UInt, title: String, subject: Subject, objectives: [Objective], createdAt: Date = .now) {
+        self.id = id
+        self.title = title
+        self.subject = subject
+        self.objectives = objectives
+        self.createdAt = createdAt
+    }
+    
+    public static let mock = Mandarat(
+        id: 1,
+        title: "SwiftUI 마스터하기",
+        subject: Subject(id: 100, content: "핵심주제\nSwiftUI 정복", isCompleted: false),
+        objectives: [
+            Objective(id: 201, content: "목표 1\n기본기", actionItems: [
+                ActionIdea(id: 301, action: "View와 Modifier", isCompleted: false),
+                ActionIdea(id: 302, action: "Layout 시스템", isCompleted: false),
+                ActionIdea(id: 303, action: "State 관리 기초", isCompleted: false),
+                ActionIdea(id: 304, action: "Preview 활용", isCompleted: false),
+                ActionIdea(id: 305, action: "SF Symbols", isCompleted: false)
+            ]),
+            Objective(id: 202, content: "목표 2\n상태 관리", actionItems: [
+                ActionIdea(id: 401, action: "@StateObject", isCompleted: false),
+                ActionIdea(id: 402, action: "@ObservedObject", isCompleted: false),
+                ActionIdea(id: 403, action: "@EnvironmentObject", isCompleted: false),
+                ActionIdea(id: 404, action: "Binding", isCompleted: false),
+                ActionIdea(id: 405, action: "데이터 흐름 이해", isCompleted: false)
+            ]),
+            Objective(id: 203, content: "목표 3\n고급 UI", actionItems: [
+                ActionIdea(id: 501, action: "Custom View", isCompleted: false),
+                ActionIdea(id: 502, action: "Animation", isCompleted: false),
+                ActionIdea(id: 503, action: "Gesture", isCompleted: false),
+                ActionIdea(id: 504, action: "Navigation", isCompleted: false),
+                ActionIdea(id: 505, action: "MatchedGeometry", isCompleted: false)
+            ]),
+            Objective(id: 204, content: "목표 4\n앱 배포", actionItems: [
+                ActionIdea(id: 601, action: "App Store Connect", isCompleted: false),
+                ActionIdea(id: 602, action: "인증서 관리", isCompleted: false),
+                ActionIdea(id: 603, action: "TestFlight", isCompleted: false),
+                ActionIdea(id: 604, action: "앱 아이콘/스샷", isCompleted: false),
+                ActionIdea(id: 605, action: "버전 관리", isCompleted: false)
+            ])
+        ]
+    )
 }

--- a/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
@@ -68,13 +68,9 @@ private extension MandaratGridGenerator {
      - Returns: `ObjectPosition` 또는 유효하지 않은 경우 `nil`
      */
     static func objectivePosition(at position: Coordinate) -> Layout.ObjectPosition? {
-        switch position {
-        case (1, 2): .top
-        case (3, 2): .bottom
-        case (2, 1): .leading
-        case (2, 3): .trailing
-        default: nil
-        }
+        let relativePositions: [Layout.ObjectPosition] = [.leading, .top, .trailing, .bottom]
+        guard let index = Layout.objectivePositions.firstIndex(where: { $0.row == position.row && $0.column == position.column }) else { return nil }
+        return relativePositions[index]
     }
 }
 

--- a/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
@@ -1,0 +1,126 @@
+//
+//  MandaratGridGenerator.swift
+//  MandaratDomain
+//
+//  Created by SwainYun on 10/12/25.
+//
+
+import Foundation
+
+/// 만다라트 데이터 모델을 기반으로 5x5 그리드 레이아웃 정보를 생성하는 역할을 맡은 타입입니다.
+public struct MandaratGridGenerator {
+    typealias Coordinate = (row: Int, column: Int)
+    
+    /// 그리드 레이아웃과 관련된 상수 값을 관리하는 이름 공간
+    enum Layout {
+        /// 그리드 내 객체의 상대적 위치
+        enum ObjectPosition {
+            case top, bottom, leading, trailing
+        }
+        /// 핵심 주제가 위치할 중앙 좌표
+        static let center: Coordinate = (2, 2)
+        /// 핵심 주제별 목표 4개가 위치할 좌표 배열 (중앙 좌표 기준으로 좌, 상, 우, 하 순서)
+        static let objectivePositions: [Coordinate] = [(2, 1), (1, 2), (2, 3), (3, 2)]
+        /// 목표별 행동 아이디어들이 위치할 좌표 딕셔너리
+        static let actionIdeaPositions: [ObjectPosition: [Coordinate]] = [
+            .top:      [(0, 0), (0, 1), (1, 0), (1, 1), (0, 2)],
+            .bottom:   [(3, 3), (4, 3), (3, 4), (4, 4), (4, 2)],
+            .leading:  [(3, 0), (4, 0), (3, 1), (4, 1), (2, 0)],
+            .trailing: [(0, 3), (0, 4), (1, 3), (1, 4), (2, 4)],
+        ]
+    }
+    
+    /**
+     주어진 `Mandarat` 데이터로부터 25개 셀의 위치 정보(`CellInfo`) 배열을 생성합니다.
+     - Parameter mandarat: 그리드를 구성할 `Mandarat` 데이터 모델.
+     - Returns: 각 셀의 위치와 데이터 정보를 담고 있는 `CellInfo` 배열.
+     */
+    public static func generate(for mandarat: Mandarat) -> [CellInfo] {
+        var infos = [CellInfo]()
+        
+        infos.append(CellInfo(dataSource: .subject(mandarat.subject), row: Layout.center.row, column: Layout.center.column))
+        
+        let objectivesWithPostions: [(Objective, Coordinate)] = Array(zip(mandarat.objectives, Layout.objectivePositions))
+        
+        for (objective, position) in objectivesWithPostions {
+            infos.append(CellInfo(dataSource: .objective(objective), row: position.row, column: position.column))
+            
+            guard let objectPosition = objectivePosition(at: position),
+                  let actionPositions = Layout.actionIdeaPositions[objectPosition]
+            else { continue }
+            
+            let actionItemsWithPositions = Array(zip(objective.actionItems, actionPositions))
+            
+            for (actionItem, actionPosition) in actionItemsWithPositions {
+                infos.append(CellInfo(dataSource: .actionIdea(actionItem), row: actionPosition.row, column: actionPosition.column))
+            }
+        }
+        
+        return infos
+    }
+}
+
+// MARK: - MandaratGridGenerator + Helper Methods
+private extension MandaratGridGenerator {
+    /**
+     주어진 좌표에 해당하는 목표의 상대적 위치 (`ObjectPosition`)를 반환합니다.
+     - Parameter Position: 확인할 목표 셀의 좌표
+     - Returns: `ObjectPosition` 또는 유효하지 않은 경우 `nil`
+     */
+    static func objectivePosition(at position: Coordinate) -> Layout.ObjectPosition? {
+        switch position {
+        case (1, 2): .top
+        case (3, 2): .bottom
+        case (2, 1): .leading
+        case (2, 3): .trailing
+        default: nil
+        }
+    }
+}
+
+/**
+ 만다라트 그리드의 단일 셀에 대한 정보
+ 
+ `Identifiable`을 준수하여 SwiftUI의 `ForEach` 구문에서 사용될 수 있습니다.
+ */
+public struct CellInfo: Identifiable, Equatable {
+    /// 셀에 표시할 데이터
+    public let dataSource: MandaratDataSource
+    /// 그리드 내 행(row) 위치
+    public let row: Int
+    /// 그리드 내 열(column) 위치
+    public let column: Int
+    /// 고유 식별자
+    public var id: UInt { dataSource.id }
+}
+
+/**
+ 만다라트 차트 내 각 셀에 표시될 데이터 유형
+ 
+ `Subject`, `Objective`, `ActionIdea` 등 서로 다른 모델을 통합하여 뷰에서 일관되게 처리할 수 있도록 도와줍니다.
+ */
+public enum MandaratDataSource: Equatable, Hashable {
+    case subject(Subject)
+    case objective(Objective)
+    case actionIdea(ActionIdea)
+    
+    /// 고유 식별자
+    ///
+    /// `matchedGeometryEffect`의 애니메이션과 `Identifiable` 준수를 위해 사용됩니다.
+    public var id: UInt {
+        switch self {
+        case .subject(let item): return item.id
+        case .objective(let item): return item.id
+        case .actionIdea(let item): return item.id
+        }
+    }
+    
+    /// 데이터 소스가 셀에 표시할 텍스트 컨텐츠입니다.
+    public var content: String {
+        switch self {
+        case .subject(let item): return item.content
+        case .objective(let item): return item.content
+        case .actionIdea(let item): return item.action
+        }
+    }
+}

--- a/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
@@ -88,17 +88,11 @@ public struct CellInfo: Identifiable, Equatable {
     public let row: Int
     /// 그리드 내 열(column) 위치
     public let column: Int
-    /// 고유 식별자
+    /// 셀의 고유 식별자
     ///
-    /// - Note: 데이터 소스가 실제 데이터를 가질 경우 해당 데이터의 식별자를 사용하고,
-    /// `.placeholder`일 경우 좌표를 기반으로 한 식별자를 생성하여 뷰 렌더링에 이용합니다.
+    /// 그리드 내 좌표를 기반으로 `ForEach`의 diffing 렌더링 등에 사용됩니다.
     public var id: UInt {
-        switch dataSource {
-        case .subject(let subject): subject.id
-        case .objective(let objective): objective.id
-        case .actionIdea(let actionIdea): actionIdea.id
-        case .placeholder: UInt(1000 + (row * 10) + column)
-        }
+        return UInt((row * 5) + column)
     }
 }
 

--- a/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/MandaratGridGenerator.swift
@@ -36,27 +36,29 @@ public struct MandaratGridGenerator {
      - Returns: 각 셀의 위치와 데이터 정보를 담고 있는 `CellInfo` 배열.
      */
     public static func generate(for mandarat: Mandarat) -> [CellInfo] {
-        var infos = [CellInfo]()
-        
-        infos.append(CellInfo(dataSource: .subject(mandarat.subject), row: Layout.center.row, column: Layout.center.column))
-        
-        let objectivesWithPostions: [(Objective, Coordinate)] = Array(zip(mandarat.objectives, Layout.objectivePositions))
-        
-        for (objective, position) in objectivesWithPostions {
-            infos.append(CellInfo(dataSource: .objective(objective), row: position.row, column: position.column))
-            
+        let subjectInfo = CellInfo(dataSource: .subject(mandarat.subject), row: Layout.center.row, column: Layout.center.column)
+        let otherInfos = Layout.objectivePositions.enumerated().flatMap { (index, position) -> [CellInfo] in
             guard let objectPosition = objectivePosition(at: position),
                   let actionPositions = Layout.actionIdeaPositions[objectPosition]
-            else { continue }
+            else { return [] }
             
-            let actionItemsWithPositions = Array(zip(objective.actionItems, actionPositions))
-            
-            for (actionItem, actionPosition) in actionItemsWithPositions {
-                infos.append(CellInfo(dataSource: .actionIdea(actionItem), row: actionPosition.row, column: actionPosition.column))
+            if mandarat.objectives.indices.contains(index) {
+                let objective = mandarat.objectives[index]
+                let objectiveCell = CellInfo(dataSource: .objective(objective), row: position.row, column: position.column)
+                let actionCells = actionPositions.enumerated().map { (index, position) -> CellInfo in
+                    guard objective.actionItems.indices.contains(index) else { return CellInfo(dataSource: .placeholder, row: position.row, column: position.column) }
+                    return CellInfo(dataSource: .actionIdea(objective.actionItems[index]), row: position.row, column: position.column)
+                }
+                
+                return [objectiveCell] + actionCells
+            } else {
+                let objectivePlaceholder = CellInfo(dataSource: .placeholder, row: position.row, column: position.column)
+                let actionPlaceholders = actionPositions.map { CellInfo(dataSource: .placeholder, row: $0.row, column: $0.column) }
+                return [objectivePlaceholder] + actionPlaceholders
             }
         }
         
-        return infos
+        return [subjectInfo] + otherInfos
     }
 }
 
@@ -87,7 +89,17 @@ public struct CellInfo: Identifiable, Equatable {
     /// 그리드 내 열(column) 위치
     public let column: Int
     /// 고유 식별자
-    public var id: UInt { dataSource.id }
+    ///
+    /// - Note: 데이터 소스가 실제 데이터를 가질 경우 해당 데이터의 식별자를 사용하고,
+    /// `.placeholder`일 경우 좌표를 기반으로 한 식별자를 생성하여 뷰 렌더링에 이용합니다.
+    public var id: UInt {
+        switch dataSource {
+        case .subject(let subject): subject.id
+        case .objective(let objective): objective.id
+        case .actionIdea(let actionIdea): actionIdea.id
+        case .placeholder: UInt(1000 + (row * 10) + column)
+        }
+    }
 }
 
 /**
@@ -99,17 +111,7 @@ public enum MandaratDataSource: Equatable, Hashable {
     case subject(Subject)
     case objective(Objective)
     case actionIdea(ActionIdea)
-    
-    /// 고유 식별자
-    ///
-    /// `matchedGeometryEffect`의 애니메이션과 `Identifiable` 준수를 위해 사용됩니다.
-    public var id: UInt {
-        switch self {
-        case .subject(let item): return item.id
-        case .objective(let item): return item.id
-        case .actionIdea(let item): return item.id
-        }
-    }
+    case placeholder
     
     /// 데이터 소스가 셀에 표시할 텍스트 컨텐츠입니다.
     public var content: String {
@@ -117,6 +119,7 @@ public enum MandaratDataSource: Equatable, Hashable {
         case .subject(let item): return item.content
         case .objective(let item): return item.content
         case .actionIdea(let item): return item.action
+        case .placeholder: return ""
         }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
@@ -13,8 +13,6 @@ struct MandaratCellView: View {
     /// 뷰의 스타일과 관련된 상수 값을 관리하는 이름 공간입니다.
     private enum Style {
         static let cornerRadius: CGFloat = 10
-        static let focusedTextPadding: CGFloat = 8
-        static let groupMemberTextPadding: CGFloat = 6
         static let groupMemberLineLimit: Int = 3
     }
     
@@ -30,17 +28,12 @@ struct MandaratCellView: View {
     let isFocused: Bool
     let isGroupMember: Bool
     let namespace: Namespace.ID
-    let focusedSize: CGFloat
-    let groupMemberSize: CGFloat
+    let activeSize: CGFloat
     let inactiveSize: CGFloat
     
     private var isVisible: Bool { isFocused || isGroupMember }
     
-    private var size: CGFloat {
-        if isFocused { return focusedSize }
-        if isGroupMember { return groupMemberSize }
-        return inactiveSize
-    }
+    private var size: CGFloat { isVisible ? activeSize : inactiveSize }
     
     private var backgroundColor: Color {
         switch dataSource {
@@ -55,7 +48,6 @@ struct MandaratCellView: View {
             .frame(width: size, height: size)
             .mandamongFont(isFocused ? .cellCore : .cellIdea)
             .multilineTextAlignment(.center)
-            .padding(isFocused ? Style.focusedTextPadding : Style.groupMemberTextPadding)
             .lineLimit(isFocused ? nil : Style.groupMemberLineLimit)
             .background(
                 RoundedRectangle(cornerRadius: Style.cornerRadius)

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
@@ -1,0 +1,70 @@
+//
+//  MandaratCellView.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/12/25.
+//
+
+import SwiftUI
+import MandaratDomain
+import DesignSystem
+
+struct MandaratCellView: View {
+    /// 뷰의 스타일과 관련된 상수 값을 관리하는 이름 공간입니다.
+    private enum Style {
+        static let cornerRadius: CGFloat = 10
+        static let focusedTextPadding: CGFloat = 8
+        static let groupMemberTextPadding: CGFloat = 6
+        static let groupMemberLineLimit: Int = 3
+    }
+    
+    /// 뷰의 투명도와 관련된 상수 값을 관리하는 이름 공간입니다.
+    private enum Opacity {
+        static let focusedSubject: Double = 0.8
+        static let visibleObjective: Double = 0.7
+        static let visibleAction: Double = 0.6
+        static let inactive: Double = 0.3
+    }
+    
+    let dataSource: MandaratDataSource
+    let isFocused: Bool
+    let isGroupMember: Bool
+    let namespace: Namespace.ID
+    let focusedSize: CGFloat
+    let groupMemberSize: CGFloat
+    let inactiveSize: CGFloat
+    
+    private var isVisible: Bool { isFocused || isGroupMember }
+    
+    private var size: CGFloat {
+        if isFocused { return focusedSize }
+        if isGroupMember { return groupMemberSize }
+        return inactiveSize
+    }
+    
+    private var backgroundColor: Color {
+        switch dataSource {
+        case .subject: .yellow.opacity(isFocused ? Opacity.focusedSubject : Opacity.inactive)
+        case .objective: .blue.opacity(isVisible ? Opacity.visibleObjective : Opacity.inactive)
+        case .actionIdea: .green.opacity(isVisible ? Opacity.visibleAction : Opacity.inactive)
+        }
+    }
+    
+    var body: some View {
+        Text(isVisible ? dataSource.content : "")
+            .frame(width: size, height: size)
+            .mandamongFont(isFocused ? .cellCore : .cellIdea)
+            .multilineTextAlignment(.center)
+            .padding(isFocused ? Style.focusedTextPadding : Style.groupMemberTextPadding)
+            .lineLimit(isFocused ? nil : Style.groupMemberLineLimit)
+            .background(
+                RoundedRectangle(cornerRadius: Style.cornerRadius)
+                    .fill(backgroundColor)
+            )
+            .matchedGeometryEffect(id: dataSource.id, in: namespace)
+    }
+}
+
+#Preview {
+    MandaratChartView(store: .init(initialState: MandaratChartFeature.State(mandarat: .mock), reducer: { MandaratChartFeature() }))
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratCellView.swift
@@ -22,14 +22,19 @@ struct MandaratCellView: View {
         static let visibleObjective: Double = 0.7
         static let visibleAction: Double = 0.6
         static let inactive: Double = 0.3
+        static let placeholder: Double = 0.2
     }
     
-    let dataSource: MandaratDataSource
+    let info: CellInfo
     let isFocused: Bool
     let isGroupMember: Bool
     let namespace: Namespace.ID
     let activeSize: CGFloat
     let inactiveSize: CGFloat
+    
+    private var id: UInt { info.id }
+    
+    private var dataSource: MandaratDataSource { info.dataSource }
     
     private var isVisible: Bool { isFocused || isGroupMember }
     
@@ -40,6 +45,7 @@ struct MandaratCellView: View {
         case .subject: .yellow.opacity(isFocused ? Opacity.focusedSubject : Opacity.inactive)
         case .objective: .blue.opacity(isVisible ? Opacity.visibleObjective : Opacity.inactive)
         case .actionIdea: .green.opacity(isVisible ? Opacity.visibleAction : Opacity.inactive)
+        case .placeholder: .mandamongSecondary.opacity(Opacity.placeholder)
         }
     }
     
@@ -53,7 +59,7 @@ struct MandaratCellView: View {
                 RoundedRectangle(cornerRadius: Style.cornerRadius)
                     .fill(backgroundColor)
             )
-            .matchedGeometryEffect(id: dataSource.id, in: namespace)
+            .matchedGeometryEffect(id: id, in: namespace)
     }
 }
 

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartFeature.swift
@@ -1,0 +1,72 @@
+//
+//  MandaratChartFeature.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/11/25.
+//
+
+import ComposableArchitecture
+import MandaratDomain
+
+@Reducer
+public struct MandaratChartFeature {
+    /// 차트에서 강조될 그룹을 의미합니다.
+    public enum ChartFocus: Hashable, Equatable {
+        /// 핵심 주제가 강조된 상태
+        case subject
+        /// 특정 목표와 행동 아이디어들이 강조된 상태
+        case objective(id: UInt)
+    }
+    
+    @ObservableState
+    public struct State: Equatable {
+        public var mandarat: Mandarat
+        public var cellInfos: [CellInfo]
+        public var focus: ChartFocus = .subject
+        
+        public init(mandarat: Mandarat) {
+            self.mandarat = mandarat
+            self.cellInfos = MandaratGridGenerator.generate(for: mandarat)
+        }
+    }
+    
+    @CasePathable
+    public enum Action {
+        public enum ViewAction {
+            case cellTapped(MandaratDataSource)
+        }
+        
+        case view(ViewAction)
+    }
+    
+    public var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case let .view(.cellTapped(dataSource)):
+                updateFocus(for: dataSource, in: &state)
+                return .none
+            }
+        }
+    }
+}
+
+// MARK: - MandaratChartFeature + Helper Methods
+private extension MandaratChartFeature {
+    /**
+     사용자가 탭한 셀 데이터에 따라 강조 상태를 갱신합니다.
+     - Parameters:
+        - dataSource: 사용자가 탭한 셀의 데이터 소스.
+        - state: 변경할 현재 `State`
+     */
+    func updateFocus(for dataSource: MandaratDataSource, in state: inout State) {
+        switch dataSource {
+        case .subject:
+            state.focus = .subject
+        case .objective(let objective):
+            state.focus = .objective(id: objective.id)
+        case .actionIdea(let actionIdea):
+            guard let superObjective = state.mandarat.objectives.first(where: { $0.actionItems.contains(where: { $0.id == actionIdea.id }) }) else { return }
+            state.focus = .objective(id: superObjective.id)
+        }
+    }
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartFeature.swift
@@ -67,6 +67,10 @@ private extension MandaratChartFeature {
         case .actionIdea(let actionIdea):
             guard let superObjective = state.mandarat.objectives.first(where: { $0.actionItems.contains(where: { $0.id == actionIdea.id }) }) else { return }
             state.focus = .objective(id: superObjective.id)
+            
+        case .placeholder:
+            // TODO: 빈 셀일 때는 만다라트 요소 추가 등의 작업 (WIP)
+            return
         }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -1,0 +1,134 @@
+//
+//  MandaratChartView.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/12/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import MandaratDomain
+
+fileprivate typealias ChartFocus = MandaratChartFeature.ChartFocus
+
+public struct MandaratChartView: View {
+    /// 뷰에서 사용되는 상수 값을 관리하는 이름 공간입니다.
+    private enum Constants {
+        static let gridSpacing: CGFloat = 10
+        static let gridRange = 0..<5
+        static let horizontalPadding: CGFloat = 16
+        
+        enum Animation {
+            static let extraBounce: CGFloat = 0.2
+        }
+        
+        /// 화면 너비에 대한 각 셀 크기 비율
+        enum SizeRatio {
+            static let focused: CGFloat = 0.32
+            static let groupMember: CGFloat = 0.16
+            static let inactive: CGFloat = 0.05
+        }
+    }
+    
+    @Bindable var store: StoreOf<MandaratChartFeature>
+    @Namespace private var animation
+    
+    public init(store: StoreOf<MandaratChartFeature>) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        GeometryReader { proxy in
+            let gridSizeLength = min(proxy.size.width, proxy.size.height)
+            let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2)
+            let focusedSize = contentWidth * Constants.SizeRatio.focused
+            let groupMemberSize = contentWidth * Constants.SizeRatio.groupMember
+            let inactiveSize = contentWidth * Constants.SizeRatio.inactive
+            
+            Grid(horizontalSpacing: Constants.gridSpacing, verticalSpacing: Constants.gridSpacing) {
+                ForEach(Constants.gridRange, id: \.self) { row in
+                    GridRow {
+                        ForEach(Constants.gridRange, id: \.self) { column in
+                            if let info = cellInfo(atRow: row, atColumn: column) {
+                                cell(for: info, focusedSize: focusedSize, groupMemberSize: groupMemberSize, inactiveSize: inactiveSize)
+                            } else {
+                                Color.clear
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(Constants.horizontalPadding)
+            .frame(width: gridSizeLength, height: gridSizeLength)
+            .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+        }
+    }
+}
+
+// MARK: - MandaratChartView + Helper Methods
+private extension MandaratChartView {
+    /**
+     주어진 행과 열에 해당하는 `CellInfo`를 찾아서 반환합니다.
+     - Parameters:
+        - row: 찾고자 하는 셀의 행.
+        - column: 찾고자 하는 셀의 열.
+     - Returns: `CellInfo` 또는 해당하는 셀이 없을 경우 `nil`
+     */
+    func cellInfo(atRow row: Int, atColumn column: Int) -> CellInfo? {
+        store.cellInfos.first { $0.row == row && $0.column == column }
+    }
+    
+    /**
+     주어진 데이터 소스와 현재 강조 상태를 기반으로 셀의 상태를 계산합니다.
+     - Parameters:
+        - dataSource: 상태를 계산할 셀의 데이터 소스.
+        - focus: 현재 뷰의 강조 상태
+     - Returns: 셀이 강조되었는지(`isFocused`), 그룹에 포함되는지(`isGroupMember`)를 나타내는 튜플.
+     */
+    func calculateCellStatus(for dataSource: MandaratDataSource, with focus: ChartFocus) -> (isFocused: Bool, isGroupMember: Bool) {
+        switch focus {
+        case .subject:
+            let isFocused = (dataSource.id == store.mandarat.subject.id)
+            return (isFocused, false)
+            
+        case .objective(let focusedID):
+            let isFocused = (dataSource.id == focusedID)
+            
+            guard let objective = store.mandarat.objectives.first(where: { $0.id == focusedID }) else { return (isFocused, false) }
+            let isGroupMember = objective.actionItems.contains { $0.id == dataSource.id }
+            return (isFocused, isGroupMember)
+        }
+    }
+}
+
+// MARK: - MandaratChartView + Subviews
+private extension MandaratChartView {
+    /// 주어진 `CellInfo`에 대한 `MandaratCellView`를 생성하고 구성합니다.
+    @ViewBuilder
+    func cell(
+        for info: CellInfo,
+        focusedSize: CGFloat,
+        groupMemberSize: CGFloat,
+        inactiveSize: CGFloat
+    ) -> some View {
+        let (isFocused, isGroupMember) = calculateCellStatus(for: info.dataSource, with: store.focus)
+        
+        MandaratCellView(
+            dataSource: info.dataSource,
+            isFocused: isFocused,
+            isGroupMember: isGroupMember,
+            namespace: animation,
+            focusedSize: focusedSize,
+            groupMemberSize: groupMemberSize,
+            inactiveSize: inactiveSize
+        )
+        .onTapGesture {
+            let animation = Animation.bouncy(extraBounce: Constants.Animation.extraBounce)
+            store.send(.view(.cellTapped(info.dataSource)), animation: animation)
+        }
+    }
+}
+
+#Preview {
+    MandaratChartView(store: .init(initialState: MandaratChartFeature.State(mandarat: .mock), reducer: { MandaratChartFeature() }))
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -87,14 +87,25 @@ private extension MandaratChartView {
     func calculateCellStatus(for dataSource: MandaratDataSource, with focus: ChartFocus) -> (isFocused: Bool, isGroupMember: Bool) {
         switch focus {
         case .subject:
-            let isFocused = (dataSource.id == store.mandarat.subject.id)
-            return (isFocused, false)
+            guard case let .subject(subject) = dataSource else { return (false, false) }
+            return (subject.id == store.mandarat.subject.id, false)
             
         case .objective(let focusedID):
-            let isFocused = (dataSource.id == focusedID)
+            var isFocused: Bool = false
+            var isGroupMember: Bool = false
             
-            guard let objective = store.mandarat.objectives.first(where: { $0.id == focusedID }) else { return (isFocused, false) }
-            let isGroupMember = objective.actionItems.contains { $0.id == dataSource.id }
+            switch dataSource {
+            case .objective(let objective):
+                isFocused = (objective.id == focusedID)
+                
+            case .actionIdea(let actionIdea):
+                guard let focusedObjective = store.mandarat.objectives.first(where: { $0.id == focusedID }) else { break }
+                isGroupMember = focusedObjective.actionItems.contains { $0.id == actionIdea.id }
+                
+            default:
+                break
+            }
+            
             return (isFocused, isGroupMember)
         }
     }
@@ -112,7 +123,7 @@ private extension MandaratChartView {
         let (isFocused, isGroupMember) = calculateCellStatus(for: info.dataSource, with: store.focus)
         
         MandaratCellView(
-            dataSource: info.dataSource,
+            info: info,
             isFocused: isFocused,
             isGroupMember: isGroupMember,
             namespace: animation,

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -25,7 +25,7 @@ public struct MandaratChartView: View {
         /// 화면 너비에 대한 각 셀 크기 비율
         enum SizeRatio {
             static let focused: CGFloat = 0.32
-            static let groupMember: CGFloat = 0.16
+            static let groupMember: CGFloat = 0.2
             static let inactive: CGFloat = 0.05
         }
     }
@@ -40,7 +40,8 @@ public struct MandaratChartView: View {
     public var body: some View {
         GeometryReader { proxy in
             let gridSizeLength = min(proxy.size.width, proxy.size.height)
-            let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2)
+            let totalSpacing = Constants.gridSpacing * CGFloat(Constants.gridRange.count - 1)
+            let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2) - totalSpacing
             let focusedSize = contentWidth * Constants.SizeRatio.focused
             let groupMemberSize = contentWidth * Constants.SizeRatio.groupMember
             let inactiveSize = contentWidth * Constants.SizeRatio.inactive

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -38,9 +38,9 @@ public struct MandaratChartView: View {
     public var body: some View {
         GeometryReader { proxy in
             let paddedViewSideLength = min(proxy.size.width, proxy.size.height)
-            let gridContentWidth = paddedViewSideLength - (Constants.horizontalPadding * 2)
+            let gridContentWidth = max(0, paddedViewSideLength - (Constants.horizontalPadding * 2))
             let totalSpacing = Constants.gridSpacing * CGFloat(Constants.gridRange.count - 1)
-            let cellAreaWidth = gridContentWidth - totalSpacing
+            let cellAreaWidth = max(0, gridContentWidth - totalSpacing)
             let totalUnitsInWorstCase = (Constants.Sizing.activeUnit * 3) + (Constants.Sizing.inactiveUnit * 2)
             let unitPixelSize = cellAreaWidth / totalUnitsInWorstCase
             let activeSize = unitPixelSize * Constants.Sizing.activeUnit

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -22,11 +22,9 @@ public struct MandaratChartView: View {
             static let extraBounce: CGFloat = 0.2
         }
         
-        /// 화면 너비에 대한 각 셀 크기 비율
-        enum SizeRatio {
-            static let focused: CGFloat = 0.32
-            static let groupMember: CGFloat = 0.2
-            static let inactive: CGFloat = 0.05
+        enum Sizing {
+            static let activeUnit: CGFloat = 5.0
+            static let inactiveUnit: CGFloat = 2.0
         }
     }
     
@@ -42,16 +40,17 @@ public struct MandaratChartView: View {
             let gridSizeLength = min(proxy.size.width, proxy.size.height)
             let totalSpacing = Constants.gridSpacing * CGFloat(Constants.gridRange.count - 1)
             let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2) - totalSpacing
-            let focusedSize = contentWidth * Constants.SizeRatio.focused
-            let groupMemberSize = contentWidth * Constants.SizeRatio.groupMember
-            let inactiveSize = contentWidth * Constants.SizeRatio.inactive
+            let totalUnitsInWorstCase = (Constants.Sizing.activeUnit * 3) + (Constants.Sizing.inactiveUnit * 2)
+            let unitPixelSize = contentWidth / totalUnitsInWorstCase
+            let activeSize = unitPixelSize * Constants.Sizing.activeUnit
+            let inactiveSize = unitPixelSize * Constants.Sizing.inactiveUnit
             
-            Grid(horizontalSpacing: Constants.gridSpacing, verticalSpacing: Constants.gridSpacing) {
+            Grid(alignment: .center, horizontalSpacing: Constants.gridSpacing, verticalSpacing: Constants.gridSpacing) {
                 ForEach(Constants.gridRange, id: \.self) { row in
                     GridRow {
                         ForEach(Constants.gridRange, id: \.self) { column in
                             if let info = cellInfo(atRow: row, atColumn: column) {
-                                cell(for: info, focusedSize: focusedSize, groupMemberSize: groupMemberSize, inactiveSize: inactiveSize)
+                                cell(for: info, activeSize: activeSize, inactiveSize: inactiveSize)
                             } else {
                                 Color.clear
                             }
@@ -59,7 +58,6 @@ public struct MandaratChartView: View {
                     }
                 }
             }
-            .padding(Constants.horizontalPadding)
             .frame(width: gridSizeLength, height: gridSizeLength)
             .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
         }
@@ -108,8 +106,7 @@ private extension MandaratChartView {
     @ViewBuilder
     func cell(
         for info: CellInfo,
-        focusedSize: CGFloat,
-        groupMemberSize: CGFloat,
+        activeSize: CGFloat,
         inactiveSize: CGFloat
     ) -> some View {
         let (isFocused, isGroupMember) = calculateCellStatus(for: info.dataSource, with: store.focus)
@@ -119,8 +116,7 @@ private extension MandaratChartView {
             isFocused: isFocused,
             isGroupMember: isGroupMember,
             namespace: animation,
-            focusedSize: focusedSize,
-            groupMemberSize: groupMemberSize,
+            activeSize: activeSize,
             inactiveSize: inactiveSize
         )
         .onTapGesture {

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -37,11 +37,12 @@ public struct MandaratChartView: View {
     
     public var body: some View {
         GeometryReader { proxy in
-            let gridSizeLength = min(proxy.size.width, proxy.size.height)
+            let paddedViewSideLength = min(proxy.size.width, proxy.size.height)
+            let gridContentWidth = paddedViewSideLength - (Constants.horizontalPadding * 2)
             let totalSpacing = Constants.gridSpacing * CGFloat(Constants.gridRange.count - 1)
-            let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2) - totalSpacing
+            let cellAreaWidth = gridContentWidth - totalSpacing
             let totalUnitsInWorstCase = (Constants.Sizing.activeUnit * 3) + (Constants.Sizing.inactiveUnit * 2)
-            let unitPixelSize = contentWidth / totalUnitsInWorstCase
+            let unitPixelSize = cellAreaWidth / totalUnitsInWorstCase
             let activeSize = unitPixelSize * Constants.Sizing.activeUnit
             let inactiveSize = unitPixelSize * Constants.Sizing.inactiveUnit
             
@@ -58,7 +59,8 @@ public struct MandaratChartView: View {
                     }
                 }
             }
-            .frame(width: gridSizeLength, height: gridSizeLength)
+            .padding(Constants.horizontalPadding)
+            .frame(width: paddedViewSideLength, height: paddedViewSideLength)
             .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
         }
     }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratChart/MandaratChartView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import ComposableArchitecture
 import MandaratDomain
 
-fileprivate typealias ChartFocus = MandaratChartFeature.ChartFocus
+private typealias ChartFocus = MandaratChartFeature.ChartFocus
 
 public struct MandaratChartView: View {
     /// 뷰에서 사용되는 상수 값을 관리하는 이름 공간입니다.


### PR DESCRIPTION
## 📄 작업 내용
- 만다라트 차트 및 셀, Reducer 추가
- 만다라트 차트 구성을 돕는 헬퍼 객체 추가

|    구현 내용    |   GIF / ScreenShot   |
| :-------------: | :----------: |
| MandaratChartView(꽉참) | <img src="https://github.com/user-attachments/assets/c6c2b4c3-f39d-48ce-b215-5cf1882ff5ab" width ="300"></img> |
| MandaratChartView(일부 요소 없음) | <img src="https://github.com/user-attachments/assets/b08c109a-0cde-4558-b95f-53d2bde727c2" width ="300"></img> |

## 💻 주요 코드 설명
### 개요
만다라트 차트는 두 가지 보기 옵션을 제공합니다: (리스트 형태, 격자 그리드 형태)
이번 PR에서는 격자 그리드 형태의 보기 옵션에 대해 구현하였습니다.

**주요 변경점**
* 핵심 주제(1개), 목표(4개), 행동 아이디어(20개) 총 25개의 셀로 이루어진 격자 그리드 형태의 만다라트 차트 컴포넌트를 추가했습니다.

---

### MandaratGridGenerator
만다라트 데이터 모델을 기반으로 5x5 그리드 레이아웃 정보를 생성합니다.

**MandaratGridGenerator.Layout**
```swift
/// 그리드 레이아웃과 관련된 상수 값을 관리하는 이름 공간
enum Layout {
    /// 그리드 내 객체의 상대적 위치
    enum ObjectPosition {
        case top, bottom, leading, trailing
    }
    /// 핵심 주제가 위치할 중앙 좌표
    static let center: Coordinate = (2, 2)
    /// 핵심 주제별 목표 4개가 위치할 좌표 배열 (중앙 좌표 기준으로 좌, 상, 우, 하 순서)
    static let objectivePositions: [Coordinate] = [(2, 1), (1, 2), (2, 3), (3, 2)]
    /// 목표별 행동 아이디어들이 위치할 좌표 딕셔너리
    static let actionIdeaPositions: [ObjectPosition: [Coordinate]] = [
        .top:      [(0, 0), (0, 1), (1, 0), (1, 1), (0, 2)],
        .bottom:   [(3, 3), (4, 3), (3, 4), (4, 4), (4, 2)],
        .leading:  [(3, 0), (4, 0), (3, 1), (4, 1), (2, 0)],
        .trailing: [(0, 3), (0, 4), (1, 3), (1, 4), (2, 4)],
    ]
}
```

5x5 격자 그리드 형태의 레이아웃을 정의합니다.
핵심 주제 셀은 그리드의 중앙에 위치하며, 목표 셀들은 핵심 주제 셀에서 한 칸씩 떨어진 곳에 위치합니다. 나머지 셀들은 행동 아이디어 셀의 영역입니다.

> 만다라트 구성 요소 별 셀의 위치를 변경하고자 한다면 Layout 이름 공간에서 좌표만 수정하면 됩니다.

---

### MandaratChartFeature
만다라트 차트와 상호작용 기능입니다.

**MandaratChartFeature.ChartFocus**
```swift
/// 차트에서 강조될 그룹을 의미합니다.
public enum ChartFocus: Hashable, Equatable {
    /// 핵심 주제가 강조된 상태
    case subject
    /// 특정 목표와 행동 아이디어들이 강조된 상태
    case objective(id: UInt)
}
```

기존 디자인 시안처럼 5x5 격자 그리드를 전부 화면에 표시하려면 화면 비율이 작은 기종에서는 내용이 잘리거나 하여 불편한 문제가 예상되었습니다.
따라서 만다라트 요소 중 일부를 크게 표시하고 보고 있지 않은 요소들은 작게 표시함으로써 디스플레이 영역을 효율적으로 사용하고자 했습니다.

만다라트 차트와의 상호작용을 통해 강조 단계를 변경할 수 있습니다.
강조 단계는 총 두 가지입니다: (핵심 주제 강조 단계, 목표 및 행동 아이디어 강조 단계)

> MandaratChartFeature는 생성 시점에 Mandarat 도메인 모델을 필요로하며, MandaratGridGenerator를 통해 셀의 위치 정보를 한 번만 계산하고 사용합니다.

---

### MandaratChartView
만다라트 차트 화면입니다.

<details>
<summary>전체 코드</summary>

```swift
import SwiftUI
import ComposableArchitecture
import MandaratDomain

fileprivate typealias ChartFocus = MandaratChartFeature.ChartFocus

public struct MandaratChartView: View {
    /// 뷰에서 사용되는 상수 값을 관리하는 이름 공간입니다.
    private enum Constants {
        static let gridSpacing: CGFloat = 10
        static let gridRange = 0..<5
        static let horizontalPadding: CGFloat = 16
        
        enum Animation {
            static let extraBounce: CGFloat = 0.2
        }
        
        enum Sizing {
            static let activeUnit: CGFloat = 5.0
            static let inactiveUnit: CGFloat = 2.0
        }
    }
    
    @Bindable var store: StoreOf<MandaratChartFeature>
    @Namespace private var animation
    
    public init(store: StoreOf<MandaratChartFeature>) {
        self.store = store
    }
    
    public var body: some View {
        GeometryReader { proxy in
            let gridSizeLength = min(proxy.size.width, proxy.size.height)
            let totalSpacing = Constants.gridSpacing * CGFloat(Constants.gridRange.count - 1)
            let contentWidth = gridSizeLength - (Constants.horizontalPadding * 2) - totalSpacing
            let totalUnitsInWorstCase = (Constants.Sizing.activeUnit * 3) + (Constants.Sizing.inactiveUnit * 2)
            let unitPixelSize = contentWidth / totalUnitsInWorstCase
            let activeSize = unitPixelSize * Constants.Sizing.activeUnit
            let inactiveSize = unitPixelSize * Constants.Sizing.inactiveUnit
            
            Grid(alignment: .center, horizontalSpacing: Constants.gridSpacing, verticalSpacing: Constants.gridSpacing) {
                ForEach(Constants.gridRange, id: \.self) { row in
                    GridRow {
                        ForEach(Constants.gridRange, id: \.self) { column in
                            if let info = cellInfo(atRow: row, atColumn: column) {
                                cell(for: info, activeSize: activeSize, inactiveSize: inactiveSize)
                            } else {
                                Color.clear
                            }
                        }
                    }
                }
            }
            .frame(width: gridSizeLength, height: gridSizeLength)
            .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
        }
    }
}

// MARK: - MandaratChartView + Helper Methods
private extension MandaratChartView {
    /**
     주어진 행과 열에 해당하는 `CellInfo`를 찾아서 반환합니다.
     - Parameters:
        - row: 찾고자 하는 셀의 행.
        - column: 찾고자 하는 셀의 열.
     - Returns: `CellInfo` 또는 해당하는 셀이 없을 경우 `nil`
     */
    func cellInfo(atRow row: Int, atColumn column: Int) -> CellInfo? {
        store.cellInfos.first { $0.row == row && $0.column == column }
    }
    
    /**
     주어진 데이터 소스와 현재 강조 상태를 기반으로 셀의 상태를 계산합니다.
     - Parameters:
        - dataSource: 상태를 계산할 셀의 데이터 소스.
        - focus: 현재 뷰의 강조 상태
     - Returns: 셀이 강조되었는지(`isFocused`), 그룹에 포함되는지(`isGroupMember`)를 나타내는 튜플.
     */
    func calculateCellStatus(for dataSource: MandaratDataSource, with focus: ChartFocus) -> (isFocused: Bool, isGroupMember: Bool) {
        switch focus {
        case .subject:
            let isFocused = (dataSource.id == store.mandarat.subject.id)
            return (isFocused, false)
            
        case .objective(let focusedID):
            let isFocused = (dataSource.id == focusedID)
            
            guard let objective = store.mandarat.objectives.first(where: { $0.id == focusedID }) else { return (isFocused, false) }
            let isGroupMember = objective.actionItems.contains { $0.id == dataSource.id }
            return (isFocused, isGroupMember)
        }
    }
}

// MARK: - MandaratChartView + Subviews
private extension MandaratChartView {
    /// 주어진 `CellInfo`에 대한 `MandaratCellView`를 생성하고 구성합니다.
    @ViewBuilder
    func cell(
        for info: CellInfo,
        activeSize: CGFloat,
        inactiveSize: CGFloat
    ) -> some View {
        let (isFocused, isGroupMember) = calculateCellStatus(for: info.dataSource, with: store.focus)
        
        MandaratCellView(
            dataSource: info.dataSource,
            isFocused: isFocused,
            isGroupMember: isGroupMember,
            namespace: animation,
            activeSize: activeSize,
            inactiveSize: inactiveSize
        )
        .onTapGesture {
            let animation = Animation.bouncy(extraBounce: Constants.Animation.extraBounce)
            store.send(.view(.cellTapped(info.dataSource)), animation: animation)
        }
    }
}
```
</details>

## 👀 리뷰어에게 전달할 사항
**개선 목표**
1. 테스트기종은 iPhone 17 Pro 였습니다.
> 이보다 더 작은 화면 비율을 가진 기종에서도 만다라트 차트 내 일부 셀이 화면 밖으로 나가지 않고 잘 보이는지 확인해야 합니다.

2. 테마 컬러(`.mandamongPrimary`) 적용해야 합니다. 현재는 만다라트 요소 별로 셀을 확인하기 용이하도록 세 가지 색상으로 표시하고 있습니다.

3. 디자인팀으로부터 새로운 디자인 가이드가 나오면 변경될 여지가 있습니다.

## 🔗 연결된 이슈
- Resolved: #37 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * Mandarat 차트 추가: 5x5 그리드로 주제·목표·액션 아이디어를 시각화합니다.
  * 자동 배치 엔진: Mandarat 데이터를 기반으로 셀 위치와 계층을 생성해 표시합니다.
  * 상호작용 개선: 셀 탭으로 주제/목표 포커스 전환 및 관련 그룹 강조가 적용됩니다.
  * UI 컴포넌트 강화: 데이터 기반 셀 렌더링, 반응형 크기 조정, 애니메이션 전환 및 미리보기 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->