### PR TITLE
[Feat] Make Mandarat Additional Components

### DIFF
--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+public typealias CompletionRate = Double
+
 /// 목표별 행동 아이디어
 public struct ActionIdea: Identifiable, Equatable, Hashable {
     public let id: UInt
@@ -25,6 +27,11 @@ public struct Objective: Identifiable, Equatable, Hashable {
     public let id:  UInt
     public var content: String
     public var actionItems: [ActionIdea]
+    public var completionRate: CompletionRate {
+        guard actionItems.isEmpty == false else { return .zero }
+        let completedCount = actionItems.filter { $0.isCompleted }.count
+        return Double(completedCount) / Double(actionItems.count)
+    }
     
     public init(id: UInt, content: String, actionItems: [ActionIdea]) {
         self.id = id
@@ -53,6 +60,12 @@ public struct Mandarat: Identifiable, Equatable {
     public var subject: Subject
     public var objectives: [Objective]
     public let createdAt: Date
+    public var completionRate: CompletionRate {
+        let actionIdeas = objectives.flatMap { $0.actionItems }
+        guard actionIdeas.isEmpty == false else { return .zero }
+        let completedCount = actionIdeas.filter { $0.isCompleted }.count
+        return Double(completedCount) / Double(actionIdeas.count)
+    }
     
     public init(id: UInt, title: String, subject: Subject, objectives: [Objective], createdAt: Date = .now) {
         self.id = id
@@ -97,4 +110,9 @@ public struct Mandarat: Identifiable, Equatable {
             ])
         ]
     )
+}
+
+public enum ProgressState {
+    case inProgress(rate: CompletionRate)
+    case completed
 }

--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -10,7 +10,7 @@ import Foundation
 public typealias CompletionRate = Double
 
 /// 목표별 행동 아이디어
-public struct ActionIdea: Identifiable, Equatable, Hashable {
+public struct ActionIdea: Identifiable, Hashable {
     public let id: UInt
     public var action: String
     public var isCompleted: Bool
@@ -23,7 +23,7 @@ public struct ActionIdea: Identifiable, Equatable, Hashable {
 }
 
 /// 핵심 주제별 목표
-public struct Objective: Identifiable, Equatable, Hashable {
+public struct Objective: Identifiable, Hashable {
     public let id:  UInt
     public var content: String
     public var actionItems: [ActionIdea]
@@ -41,7 +41,7 @@ public struct Objective: Identifiable, Equatable, Hashable {
 }
 
 /// 핵심 주제
-public struct Subject: Identifiable, Equatable, Hashable {
+public struct Subject: Identifiable, Hashable {
     public let id: UInt
     public var content: String
     public var isCompleted: Bool
@@ -54,7 +54,7 @@ public struct Subject: Identifiable, Equatable, Hashable {
 }
 
 /// 만다라트 차트
-public struct Mandarat: Identifiable, Equatable {
+public struct Mandarat: Identifiable, Hashable {
     public let id: UInt
     public var title: String
     public var subject: Subject
@@ -110,9 +110,4 @@ public struct Mandarat: Identifiable, Equatable {
             ])
         ]
     )
-}
-
-public enum ProgressState {
-    case inProgress(rate: CompletionRate)
-    case completed
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/Components/StatusTagView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/Components/StatusTagView.swift
@@ -90,7 +90,6 @@ public struct StatusTagView: View {
                     .fill(.mandamongSecondary)
                     .strokeBorder(.mandamongPrimary)
             )
-            .clipShape(.capsule)
     }
 }
 

--- a/Projects/Mandarat/MandaratFeature/Sources/Components/StatusTagView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/Components/StatusTagView.swift
@@ -1,0 +1,107 @@
+//
+//  StatusTagView.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/15/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+public enum StatusTagStyle {
+    case label
+    case completionRate
+}
+
+private struct StatusTagStyleKey: EnvironmentKey {
+    typealias Value = StatusTagStyle
+    static let defaultValue: Value = .label
+}
+
+extension EnvironmentValues {
+    var tagStyle: StatusTagStyle {
+        get { self[StatusTagStyleKey.self] }
+        set { self[StatusTagStyleKey.self] = newValue }
+    }
+}
+
+// MARK: - View + Helper Methods
+public extension View where Self == StatusTagView {
+    func tagStyle(_ style: StatusTagStyle) -> some View {
+        self.environment(\.tagStyle, style)
+    }
+}
+
+public struct StatusTagView: View {
+    public typealias CompletionRate = Double
+    private struct Constants {
+        static let completed = "완료"
+        static let progress = "진행 중"
+        static let gradientOpacity: CGFloat = 0.6
+    }
+    
+    @Environment(\.tagStyle) private var style
+    
+    private let rate: CompletionRate
+    
+    public init(rate: CompletionRate) {
+        self.rate = rate
+    }
+    
+    public var body: some View {
+        switch style {
+        case .label:
+            labelView()
+        case .completionRate:
+            completionRateView()
+        }
+    }
+    
+    @ViewBuilder
+    private func labelView() -> some View {
+        let isCompleted: Bool = (rate >= 1.0)
+        let text: String = isCompleted ? Constants.completed : Constants.progress
+        let backgroundGradient = LinearGradient(
+            colors: isCompleted ? [.green.opacity(Constants.gradientOpacity), .green] : [.mandamongPrimary.opacity(Constants.gradientOpacity), .mandamongPrimary],
+            startPoint: .bottomLeading,
+            endPoint: .topTrailing
+        )
+        
+        Text(text)
+            .mandamongFont(.caption)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .foregroundStyle(.white)
+            .background(backgroundGradient)
+            .clipShape(.capsule)
+    }
+    
+    @ViewBuilder
+    private func completionRateView() -> some View {
+        let percentageText: String = .init(format: "%0.0f%%", rate * 100)
+        
+        Text(percentageText)
+            .mandamongFont(.caption)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .foregroundStyle(.white)
+            .background(
+                Capsule()
+                    .fill(.mandamongSecondary)
+                    .strokeBorder(.mandamongPrimary)
+            )
+            .clipShape(.capsule)
+    }
+}
+
+#Preview {
+    StatusTagView(rate: 0.534)
+    
+    StatusTagView(rate: 1.0)
+    
+    StatusTagView(rate: 0.534)
+        .tagStyle(.completionRate)
+    
+    StatusTagView(rate: 1)
+        .tagStyle(.completionRate)
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/Components/StickProgressViewStyle.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/Components/StickProgressViewStyle.swift
@@ -1,0 +1,70 @@
+//
+//  StickProgressViewStyle.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/15/25.
+//
+
+import SwiftUI
+
+public struct StickProgressViewStyle: ProgressViewStyle {
+    private struct Constants {
+        static let defaultHeight: CGFloat = 4.0
+        static let gradientOpacity: Double = 0.6
+    }
+    
+    public func makeBody(configuration: Configuration) -> some View {
+        let fractionCompleted = configuration.fractionCompleted ?? .zero
+        let isCompleted = (fractionCompleted >= 1.0)
+        let fillGradient = LinearGradient(
+            colors: isCompleted ? [.green.opacity(Constants.gradientOpacity), .green] : [.mandamongPrimary.opacity(Constants.gradientOpacity), .mandamongPrimary],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        let trackGradient = LinearGradient(
+            colors: [.mandamongSecondary.opacity(Constants.gradientOpacity), .mandamongSecondary],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(trackGradient)
+                
+                Capsule()
+                    .fill(fillGradient)
+                    .frame(width: proxy.size.width * fractionCompleted)
+                    .animation(.snappy, value: fractionCompleted)
+            }
+        }
+        .frame(maxHeight: Constants.defaultHeight)
+        .clipShape(.capsule)
+    }
+}
+
+// MARK: - View + Helper Methods
+public extension ProgressViewStyle where Self == StickProgressViewStyle {
+    static var stick: StickProgressViewStyle { .init() }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        ProgressView(value: 1)
+            .progressViewStyle(.linear)
+        
+        ProgressView(value: 1)
+            .progressViewStyle(.stick)
+        
+        ProgressView(value: 0.567)
+            .progressViewStyle(.stick)
+        
+        ProgressView(value: 0.05)
+            .progressViewStyle(.stick)
+        
+        ProgressView(value: 0)
+            .progressViewStyle(.stick)
+        
+    }
+    .padding()
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/Components/StickProgressViewStyle.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/Components/StickProgressViewStyle.swift
@@ -39,7 +39,6 @@ public struct StickProgressViewStyle: ProgressViewStyle {
             }
         }
         .frame(maxHeight: Constants.defaultHeight)
-        .clipShape(.capsule)
     }
 }
 


### PR DESCRIPTION
## 📄 작업 내용
- MandaratFeature 관련 재사용이 예상되는 UI Component 도출해 추가
    - 캡슐형 만다라트 달성률 표시 뱃지
    - 막대형 커스텀 프로그래스뷰

|    구현 내용    |   GIF / ScreenShot   |
| :-------------: | :----------: |
| 참고한 디자인(만다몽 웹) | <img src = "https://github.com/user-attachments/assets/408c0cd6-4049-4537-99ce-e7430f9dbbae" width ="500"></img> |
| StatusTagView | <img src = "https://github.com/user-attachments/assets/1fe7718a-7746-41a3-84b2-e5a784bf9499" width ="250"></img> |
| StickProgressViewStyle | <img src = "https://github.com/user-attachments/assets/c6167789-9129-4780-a413-6c50421f1063" width ="327"></img> |

### 개요
만다라트 달성률 관련 UI 요소들을 추가했습니다.
1. 캡슐형 달성율 표시 뱃지
2. 막대형 커스텀 프로그레스뷰

---

### StatusTagView
캡슐형 만다라트 달성률 표시 뱃지입니다.

**주요 변경점**
달성률 값(0 이상, 1 이하)을 전달해 선언합니다.
만약 달성률 값이 1 미만이라면 '진행 중', 아니라면 '완료' 상태로 칩니다.
완료상태에 대한 텍스트를 표시할 수도 있고, 달성률 퍼센테이지를 표시할 수도 있습니다. (퍼센테이지 표시 중일 경우에는 배경색이 고정입니다.)
퍼센테이지 값은 `Double` 타입으로 계산되지만 표시할 때에는 소수점을 이하를 표시하지 않습니다.
다음은 선언부 예제 코드이며, 문서 상단의 스크린샷과 같습니다.

```swift
VStack {
    // 라벨, 진행 중
    StatusTagView(rate: 0.534)
    
    // 라벨, 완료
    StatusTagView(rate: 1.0)
    
    // 달성률 퍼센테이지, 진행 중
    StatusTagView(rate: 0.534)
        .tagStyle(.completionRate)
    
    // 달성률 퍼센테이지, 완료
    StatusTagView(rate: 1)
        .tagStyle(.completionRate)
}
```

---

### StickProgressViewStyle
막대형 커스텀 프로그레스뷰 스타일 정의입니다.

**주요 변경점**
달성률 값(0 이상, 1 이하)을 전달해 선언합니다.
만약 달성률 값이 1 미만이라면 '진행 중', 아니라면 '완료' 상태로 칩니다.
트랙막대는 항상 세컨더리이며, 완료상태에 따라 채워지는 색상이 다릅니다.
다음은 선언부 예제 코드이며, 문서 상단의 스크린샷과 같습니다.

```swift
VStack(spacing: 20) {
    // SwiftUI 기본 막대형 프로그레스뷰, 완료
    ProgressView(value: 1)
        .progressViewStyle(.linear)
    
    // 커스텀, 완료
    ProgressView(value: 1)
        .progressViewStyle(.stick)
    
    // 커스텀, 진행 중(약 절반)
    ProgressView(value: 0.567)
        .progressViewStyle(.stick)
    
    // 커스텀, 진행 중(극 초반)
    ProgressView(value: 0.05)
        .progressViewStyle(.stick)
    
    // 커스텀, 진행 중(아무것도 완료하지 않음)
    ProgressView(value: 0)
        .progressViewStyle(.stick)
    
}
.padding()
```

---

## 리뷰어에게 전달할 사항

만다몽 웹에서 참고한 디자인을 존중하여 위 요소들의 색상은 그라데이션이 적용되어 있습니다. (변화량 0.6)
만약 티가 안난다고 하면 변화량을 조정하는 것도 고려할 수 있습니다. 

## 🔗 연결된 이슈
- Resolved: #41 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 목표와 만다라트의 완료율을 계산해 UI에 표시합니다(빈 상태 안전 처리).
  * 완료/진행 중을 보여주는 상태 태그 추가 — 라벨 또는 완료율(%) 배지 제공.
  * 태그 스타일을 뷰 환경에서 설정해 일관된 표시 적용이 가능해졌습니다.
  * 새로운 막대형(Stick) 진행도 스타일로 그라디언트 채움과 부드러운 애니메이션을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->