### PR TITLE
[Feat] 만다라트 상세 화면 구현

### DIFF
--- a/Projects/Mandarat/MandaratDomain/Sources/AppStorageKey.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/AppStorageKey.swift
@@ -1,0 +1,13 @@
+//
+//  AppStorageKey.swift
+//  MandaratDomain
+//
+//  Created by SwainYun on 10/20/25.
+//
+
+import Foundation
+
+/// AppStorage CRUD에 사용되는 키의 이름 공간
+public struct AppStorageKey {
+    public static let mandaratPresentationMode: String = "MandaratPresentationMode"
+}

--- a/Projects/Mandarat/MandaratDomain/Sources/AppStorageKey.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/AppStorageKey.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 /// AppStorage CRUD에 사용되는 키의 이름 공간
-public struct AppStorageKey {
+public enum AppStorageKey {
     public static let mandaratPresentationMode: String = "MandaratPresentationMode"
 }

--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -84,7 +84,7 @@ extension Mandarat {
         subject: Subject(id: 100, content: "SwiftUI 정복", isCompleted: false),
         objectives: [
             Objective(id: 201, content: "기본기", actionItems: [
-                ActionIdea(id: 301, action: "View와 Modifier", isCompleted: true), // 완료
+                ActionIdea(id: 301, action: "View와 Modifier", isCompleted: true),
                 ActionIdea(id: 302, action: "Layout 시스템", isCompleted: false),
                 ActionIdea(id: 303, action: "State 관리 기초", isCompleted: false),
                 ActionIdea(id: 304, action: "Preview 활용", isCompleted: false),
@@ -111,12 +111,8 @@ extension Mandarat {
                 ActionIdea(id: 604, action: "앱 아이콘/스샷", isCompleted: false),
                 ActionIdea(id: 605, action: "버전 관리", isCompleted: false)
             ]),
-            Objective(id: 205, content: "TCA", actionItems: []),
-            Objective(id: 206, content: "네트워킹", actionItems: []),
-            Objective(id: 207, content: "데이터 저장", actionItems: []),
-            Objective(id: 208, content: "배포 자동화", actionItems: []),
         ],
-        createdAt: Date().addingTimeInterval(-86400 * 3) // 3일 전 생성
+        createdAt: Date().addingTimeInterval(-86400 * 3)
     )
 
     public static let mockCompleted = Mandarat(
@@ -137,12 +133,8 @@ extension Mandarat {
                 ActionIdea(id: 806, action: "채소 위주", isCompleted: true)
             ]),
             Objective(id: 704, content: "간식", actionItems: []),
-            Objective(id: 705, content: "음료", actionItems: []),
-            Objective(id: 706, content: "영양제", actionItems: []),
-            Objective(id: 707, content: "치팅데이", actionItems: []),
-            Objective(id: 708, content: "장보기", actionItems: []),
         ],
-        createdAt: Date().addingTimeInterval(-86400 * 7) // 1주일 전 생성
+        createdAt: Date().addingTimeInterval(-86400 * 7)
     )
 
     public static let mockInProgress = Mandarat(
@@ -150,25 +142,21 @@ extension Mandarat {
         title: "블로그 포스팅",
         subject: Subject(id: 300, content: "주 2회 포스팅", isCompleted: false),
         objectives: [
-            Objective(id: 901, content: "아이디어", actionItems: [ // 2/2 완료
+            Objective(id: 901, content: "아이디어", actionItems: [
                 ActionIdea(id: 1001, action: "브레인스토밍", isCompleted: true),
                 ActionIdea(id: 1002, action: "키워드 리서치", isCompleted: true)
             ]),
-            Objective(id: 902, content: "초안 작성", actionItems: [ // 1/2 진행
+            Objective(id: 902, content: "초안 작성", actionItems: [
                 ActionIdea(id: 1003, action: "1번 포스트 초안", isCompleted: true),
                 ActionIdea(id: 1004, action: "2번 포스트 초안", isCompleted: false)
             ]),
-            Objective(id: 903, content: "발행", actionItems: [ // 0/2 진행
+            Objective(id: 903, content: "발행", actionItems: [
                 ActionIdea(id: 1005, action: "1번 포스트 발행", isCompleted: false),
                 ActionIdea(id: 1006, action: "2번 포스트 발행", isCompleted: false)
             ]),
             Objective(id: 904, content: "홍보", actionItems: []),
-            Objective(id: 905, content: "통계", actionItems: []),
-            Objective(id: 906, content: "시리즈물", actionItems: []),
-            Objective(id: 907, content: "협업", actionItems: []),
-            Objective(id: 908, content: "개선", actionItems: []),
         ],
-        createdAt: Date().addingTimeInterval(-86400 * 2) // 2일 전 생성
+        createdAt: Date().addingTimeInterval(-86400 * 2)
     )
 
     public static let mockNew = Mandarat(
@@ -187,15 +175,10 @@ extension Mandarat {
             Objective(id: 1104, content: "기술 스택", actionItems: [
                 ActionIdea(id: 1204, action: "SwiftUI + TCA", isCompleted: false)
             ]),
-            Objective(id: 1105, content: "디자인", actionItems: []),
-            Objective(id: 1106, content: "마케팅", actionItems: []),
-            Objective(id: 1107, content: "일정", actionItems: []),
-            Objective(id: 1108, content: "리스크", actionItems: []),
         ],
-        createdAt: Date() // 오늘 생성
+        createdAt: Date()
     )
 
-    /// 만다라트 Mock 배열.
     public static let mocks: [Mandarat] = [
         .mock,
         .mockCompleted,

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
@@ -10,17 +10,53 @@ import MandaratDomain
 
 @Reducer
 struct MandaratDetailFeature {
+    /// 만다라트 표시 옵션
+    ///
+    /// - Note: AppStorage 사용을 위해 `String` 원시값을 갖습니다.
+    enum PresentationMode: String {
+        case list, grid
+    }
+    
     @ObservableState
     struct State: Equatable {
         var mandarat: Mandarat
+        
+        var mandaratChartFeatureState: MandaratChartFeature.State
+        var mandaratListFeatureState: MandaratListFeature.State
+        
+        @Shared(.appStorage(AppStorageKey.mandaratPresentationMode)) var mode: PresentationMode = .grid
+        
+        init(mandarat: Mandarat) {
+            self.mandarat = mandarat
+            mandaratChartFeatureState = .init(mandarat: mandarat)
+            mandaratListFeatureState = .init(mandarat: mandarat)
+        }
     }
     
     @CasePathable
-    enum Action {
-        
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case mandaratChartFeatureAction(MandaratChartFeature.Action)
+        case mandaratListFeatureAction(MandaratListFeature.Action)
     }
     
     var body: some Reducer<State, Action> {
+        BindingReducer()
         
+        Scope(state: \.mandaratChartFeatureState, action: \.mandaratChartFeatureAction) { MandaratChartFeature() }
+        Scope(state: \.mandaratListFeatureState, action: \.mandaratListFeatureAction) { MandaratListFeature() }
+        
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+                
+            case .mandaratChartFeatureAction:
+                return .none
+                
+            case .mandaratListFeatureAction:
+                return .none
+            }
+        }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
@@ -10,22 +10,42 @@ import ComposableArchitecture
 import MandaratDomain
 import DesignSystem
 
-// TODO: 만다라트 상세 화면 구현(목록형, 그리드형 보기 옵션 전환 등)
+private typealias PresentationMode = MandaratDetailFeature.PresentationMode
+
 struct MandaratDetailView: View {
+    private struct Constants {
+        static let modePickerTitle: String = "만다라트 표시 옵션"
+        static let gridIconName: String = "rectangle.split.2x2.fill"
+        static let listIconName: String = "list.bullet"
+    }
+    
     @Bindable var store: StoreOf<MandaratDetailFeature>
     
     var body: some View {
-        VStack(spacing: 10) {
-            Text("만다라트 상세 화면")
-                .mandamongFont(.title)
-            
-            Text(store.mandarat.title)
-            
-            Text(store.mandarat.subject.content)
+        VStack {
+            switch store.mode {
+            case .grid:
+                MandaratChartView(store: store.scope(state: \.mandaratChartFeatureState, action: \.mandaratChartFeatureAction))
+                
+            case .list:
+                MandaratListView(store: store.scope(state: \.mandaratListFeatureState, action: \.mandaratListFeatureAction))
+            }
+        }
+        .navigationTitle(store.mandarat.title)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Picker(Constants.modePickerTitle, selection: $store.mode) {
+                    Image(systemName: Constants.gridIconName).tag(PresentationMode.grid)
+                    Image(systemName: Constants.listIconName).tag(PresentationMode.list)
+                }
+                .pickerStyle(.segmented)
+            }
         }
     }
 }
 
 #Preview {
-    MandaratDetailView(store: .init(initialState: MandaratDetailFeature.State(mandarat: .mock), reducer: { MandaratDetailFeature() }))
+    NavigationStack {
+        MandaratDetailView(store: .init(initialState: MandaratDetailFeature.State(mandarat: .mock), reducer: { MandaratDetailFeature() }))
+    }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
@@ -35,8 +35,13 @@ struct MandaratDetailView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Picker(Constants.modePickerTitle, selection: $store.mode) {
-                    Image(systemName: Constants.gridIconName).tag(PresentationMode.grid)
-                    Image(systemName: Constants.listIconName).tag(PresentationMode.list)
+                    Image(systemName: Constants.gridIconName)
+                        .tag(PresentationMode.grid)
+                        .accessibilityLabel(Mandamong.Strings.Common.grid)
+                    
+                    Image(systemName: Constants.listIconName)
+                        .tag(PresentationMode.list)
+                        .accessibilityLabel(Mandamong.Strings.Common.list)
                 }
                 .pickerStyle(.segmented)
             }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
@@ -20,30 +20,43 @@ struct MandaratListView: View {
     var body: some View {
         List {
             Section(Mandamong.Strings.Mandarat.subject) {
-                Text(store.mandarat.subject.content)
+                cellLabel(store.mandarat.subject.content, completionRate: store.mandarat.completionRate)
             }
-            
+
             Section(Mandamong.Strings.Mandarat.objective) {
                 ForEach($store.mandarat.objectives) { $objective in
                     DisclosureGroup {
                         ForEach($objective.actionItems) { $actionIdea in
                             Toggle(isOn: $actionIdea.isCompleted) {
                                 Text(actionIdea.action)
-                                    .strikethrough(actionIdea.isCompleted, color: .secondary)
+                                    .strikethrough(actionIdea.isCompleted)
+                                    .foregroundStyle(actionIdea.isCompleted ? .mandamongSecondary : .mandamongPrimary)
                             }
                         }
                     } label: {
-                        Text(objective.content)
+                        cellLabel(objective.content, completionRate: objective.completionRate)
                     }
                 }
             }
         }
-        .navigationTitle(store.mandarat.title)
+    }
+    
+    @ViewBuilder
+    private func cellLabel(_ title: String, completionRate: CompletionRate) -> some View {
+        VStack {
+            HStack {
+                Text(title)
+                
+                Spacer()
+                
+                StatusTagView(rate: completionRate)
+            }
+            
+            ProgressView(value: completionRate).progressViewStyle(.stick)
+        }
     }
 }
 
 #Preview {
-    NavigationStack {
-        MandaratListView(store: .init(initialState: MandaratListFeature.State.init(mandarat: .mock), reducer: { MandaratListFeature() }))
-    }
+    MandaratListView(store: .init(initialState: MandaratListFeature.State.init(mandarat: .mock), reducer: { MandaratListFeature() }))
 }

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -14,6 +14,11 @@ public enum Mandamong { }
 extension Mandamong {
     /// 문자열 리터럴
     public enum Strings {
+        public enum Common {
+            public static let grid: String = "격자형"
+            public static let list: String = "목록형"
+        }
+        
         /// 로그인 화면 관련 리터럴
         public enum Login {
             public static let title: String = "로그인"


### PR DESCRIPTION
## 📄 작업 내용
- 만다라트 상세 화면을 추가했습니다.
   - 목록형 만다라트 화면의 디자인을 변경했습니다. (WIP)
   - 선호하는 만다라트 보기 옵션(목록형, 그리드형)을 기억하도록 AppStorage를 사용합니다.

---

|    구현 내용    |   GIF / ScreenShot   |
| :-------------: | :----------: |
| 만다라트 메인 -> 만다라트 상세 | <img src = "https://github.com/user-attachments/assets/5bf4929c-962a-4b5b-8fa3-a65f77312c38" width ="250"> |

---

**주요 변경점**
1. 행동 아이디어 및 핵심 주제 달성률을 표시할 수 있습니다. 관련 디자인 및 레이아웃이 변경되었습니다. (스크린샷 참고)
2. 만다라트 상세 화면 내에서 목록형, 그리드형 보기 옵션을 전환할 수 있습니다.


## 👀 리뷰어에게 전달할 사항
* 여전히 디자인 변경 가능성이 존재합니다.
* 만다라트 및 하위 요소 추가, 수정, 삭제 기능 구현이 필요합니다.

## 🔗 연결된 이슈
- Resolved: #46 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 만다라트 상세 보기에서 격자형과 목록형 간 전환할 수 있는 토글 추가
  * 목록 보기에서 항목별 완료율 표시 추가
  * 완료 상태를 시각적으로 나타내는 진행 표시줄 표시

* **개선사항**
  * 테스트 데이터 정리 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->