### PR TITLE
[Feat] Mandarat 완료 로직 개선 및 CRUD 기능 추가

### DIFF
--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -76,6 +76,14 @@ public struct Mandarat: Identifiable, Hashable {
     }
 }
 
+/// 만다라트 도메인 규칙
+public enum MandaratRules {
+    /// 만다라트가 가질 수 있는 최대 목표(`Objectvie`) 개수입니다.
+    public static let maxObjectives: Int = 4
+    /// 하나의 목표가 가질 수 있는 최대 행동 아이디어(`ActionIdea`) 개수입니다.
+    public static let maxActionIdeas: Int = 5
+}
+
 // MARK: - Mandarat + Mock
 extension Mandarat {
     public static let mock = Mandarat(

--- a/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
+++ b/Projects/Mandarat/MandaratDomain/Sources/Entities/Mandarat.swift
@@ -61,10 +61,9 @@ public struct Mandarat: Identifiable, Hashable {
     public var objectives: [Objective]
     public let createdAt: Date
     public var completionRate: CompletionRate {
-        let actionIdeas = objectives.flatMap { $0.actionItems }
-        guard actionIdeas.isEmpty == false else { return .zero }
-        let completedCount = actionIdeas.filter { $0.isCompleted }.count
-        return Double(completedCount) / Double(actionIdeas.count)
+        guard objectives.isEmpty == false else { return .zero }
+        let completedObjectivesCount = objectives.filter { $0.completionRate == 1.0 }.count
+        return Double(completedObjectivesCount) / Double(objectives.count)
     }
     
     public init(id: UInt, title: String, subject: Subject, objectives: [Objective], createdAt: Date = .now) {

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratCellView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratCellView.swift
@@ -62,7 +62,3 @@ struct MandaratCellView: View {
             .matchedGeometryEffect(id: id, in: namespace)
     }
 }
-
-#Preview {
-    MandaratChartView(store: .init(initialState: MandaratChartFeature.State(mandarat: .mock), reducer: { MandaratChartFeature() }))
-}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratChartView.swift
@@ -31,8 +31,20 @@ struct MandaratChartView: View {
     @Bindable var store: StoreOf<MandaratChartFeature>
     @Namespace private var animation
     
-    init(store: StoreOf<MandaratChartFeature>) {
+    let onEditSubject: (Subject) -> Void
+    let onEditObjective: (Objective) -> Void
+    let onEditActionIdea: (ActionIdea) -> Void
+    
+    init(
+        store: StoreOf<MandaratChartFeature>,
+        onEditSubject: @escaping (Subject) -> Void,
+        onEditObjective: @escaping (Objective) -> Void,
+        onEditActionIdea: @escaping (ActionIdea) -> Void
+    ) {
         self.store = store
+        self.onEditSubject = onEditSubject
+        self.onEditObjective = onEditObjective
+        self.onEditActionIdea = onEditActionIdea
     }
     
     var body: some View {
@@ -135,6 +147,14 @@ private extension MandaratChartView {
         .onTapGesture {
             let animation = Animation.bouncy(extraBounce: Constants.Animation.extraBounce)
             store.send(.view(.cellTapped(info.dataSource)), animation: animation)
+        }
+        .onLongPressGesture {
+            switch info.dataSource {
+            case .subject(let subject): onEditSubject(subject)
+            case .objective(let objective): onEditObjective(objective)
+            case .actionIdea(let actionIdea): onEditActionIdea(actionIdea)
+            case .placeholder: return
+            }
         }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratChartView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratChart/MandaratChartView.swift
@@ -140,5 +140,11 @@ private extension MandaratChartView {
 }
 
 #Preview {
-    MandaratChartView(store: .init(initialState: MandaratChartFeature.State(mandarat: .mock), reducer: { MandaratChartFeature() }))
+    MandaratChartView(store: .init(initialState: MandaratChartFeature.State(mandarat: .mock), reducer: { MandaratChartFeature() })) { _ in
+        ()
+    } onEditObjective: { _ in
+        ()
+    } onEditActionIdea: { _ in
+        ()
+    }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
@@ -26,6 +26,8 @@ struct MandaratDetailFeature {
         
         @Shared(.appStorage(AppStorageKey.mandaratPresentationMode)) var mode: PresentationMode = .grid
         
+        @Presents var mandaratEditFeatureState: MandaratEditFeature.State?
+        
         init(mandarat: Mandarat) {
             self.mandarat = mandarat
             mandaratChartFeatureState = .init(mandarat: mandarat)
@@ -37,10 +39,14 @@ struct MandaratDetailFeature {
     enum Action: BindableAction {
         enum ViewAction {
             case tapDeleteButton
+            case tapEditSubjectButton(Subject)
+            case tapEditObjectiveButton(Objective)
+            case tapEditActionIdeaButton(ActionIdea)
         }
         
         enum DelegateAction {
             case deleteMandarat(Mandarat.ID)
+            case didUpdateMandarat(Mandarat)
         }
         
         case view(ViewAction)
@@ -48,6 +54,7 @@ struct MandaratDetailFeature {
         case binding(BindingAction<State>)
         case mandaratChartFeatureAction(MandaratChartFeature.Action)
         case mandaratListFeatureAction(MandaratListFeature.Action)
+        case mandaratEditFeatureAction(PresentationAction<MandaratEditFeature.Action>)
     }
     
     var body: some Reducer<State, Action> {
@@ -61,18 +68,74 @@ struct MandaratDetailFeature {
             case .view(.tapDeleteButton):
                 return .send(.delegate(.deleteMandarat(state.mandarat.id)))
                 
-            case .delegate:
+            case let .view(.tapEditSubjectButton(subject)):
+                state.mandaratEditFeatureState = .init(target: .subject(id: subject.id, currentContent: subject.content))
                 return .none
                 
-            case .binding:
+            case let .view(.tapEditObjectiveButton(objective)):
+                state.mandaratEditFeatureState = .init(target: .objective(id: objective.id, currentContent: objective.content))
                 return .none
                 
-            case .mandaratChartFeatureAction:
+            case let .view(.tapEditActionIdeaButton(actionIdea)):
+                state.mandaratEditFeatureState = .init(target: .actionIdea(id: actionIdea.id, currentContent: actionIdea.action))
                 return .none
                 
-            case .mandaratListFeatureAction:
+            case let .mandaratEditFeatureAction(.presented(.delegate(.saveCompleted(target, newContent, cascade)))):
+                updateMandaratElement(mandarat: &state.mandarat, target: target, newContent: newContent, cascade: cascade)
+                state.mandaratChartFeatureState.mandarat = state.mandarat
+                state.mandaratListFeatureState.mandarat = state.mandarat
+                return .send(.delegate(.didUpdateMandarat(state.mandarat)))
+                
+            case .delegate, .binding, .mandaratChartFeatureAction, .mandaratListFeatureAction, .mandaratEditFeatureAction:
                 return .none
             }
+        }
+        .ifLet(\.$mandaratEditFeatureState, action: \.mandaratEditFeatureAction) { MandaratEditFeature() }
+    }
+    
+    // TODO: 추후 MandaratRepository 인터페이스 사용
+    // 임시 Helper Method
+    private func updateMandaratElement(
+        mandarat: inout Mandarat,
+        target: MandaratEditFeature.EditTarget,
+        newContent: String,
+        cascade: Bool
+    ) {
+        switch target {
+        case let .subject(id, _):
+            guard mandarat.subject.id == id else { return }
+            mandarat.subject.content = newContent
+            
+            guard cascade else { return }
+            mandarat.objectives = mandarat.objectives.map { objective in
+                var newObjective = objective
+                newObjective.content = "temp-objective"
+                newObjective.actionItems = newObjective.actionItems.map { actionIdea in
+                    var newActionIdea = actionIdea
+                    newActionIdea.action = "temp-action-idea"
+                    newActionIdea.isCompleted = false
+                    return newActionIdea
+                }
+                return newObjective
+            }
+            
+        case let .objective(id, _):
+            guard let objectiveIndex = mandarat.objectives.firstIndex(where: { $0.id == id }) else { return }
+            mandarat.objectives[objectiveIndex].content = newContent
+            
+            guard cascade else { return }
+            mandarat.objectives[objectiveIndex].actionItems = mandarat.objectives[objectiveIndex].actionItems.map { actionIdea in
+                var newActionIdea = actionIdea
+                newActionIdea.action = "temp-action-idea"
+                newActionIdea.isCompleted = false
+                return newActionIdea
+            }
+            
+        case let .actionIdea(id, _):
+            guard let objectiveIndex = mandarat.objectives.firstIndex(where: { $0.actionItems.contains(where: { $0.id == id }) }),
+                  let actionIdeaIndex = mandarat.objectives[objectiveIndex].actionItems.firstIndex(where: { $0.id == id })
+            else { return }
+            mandarat.objectives[objectiveIndex].actionItems[actionIdeaIndex].action = newContent
         }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailFeature.swift
@@ -35,6 +35,16 @@ struct MandaratDetailFeature {
     
     @CasePathable
     enum Action: BindableAction {
+        enum ViewAction {
+            case tapDeleteButton
+        }
+        
+        enum DelegateAction {
+            case deleteMandarat(Mandarat.ID)
+        }
+        
+        case view(ViewAction)
+        case delegate(DelegateAction)
         case binding(BindingAction<State>)
         case mandaratChartFeatureAction(MandaratChartFeature.Action)
         case mandaratListFeatureAction(MandaratListFeature.Action)
@@ -48,6 +58,12 @@ struct MandaratDetailFeature {
         
         Reduce { state, action in
             switch action {
+            case .view(.tapDeleteButton):
+                return .send(.delegate(.deleteMandarat(state.mandarat.id)))
+                
+            case .delegate:
+                return .none
+                
             case .binding:
                 return .none
                 

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
@@ -17,6 +17,7 @@ struct MandaratDetailView: View {
         static let modePickerTitle: String = "만다라트 표시 옵션"
         static let gridIconName: String = "rectangle.split.2x2.fill"
         static let listIconName: String = "list.bullet"
+        static let deleteIconName: String = "trash"
     }
     
     @Bindable var store: StoreOf<MandaratDetailFeature>
@@ -33,7 +34,14 @@ struct MandaratDetailView: View {
         }
         .navigationTitle(store.mandarat.title)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button(role: .destructive) {
+                    store.send(.view(.tapDeleteButton))
+                } label: {
+                    Image(systemName: Constants.deleteIconName)
+                }
+                .accessibilityLabel(Mandamong.Strings.Common.delete)
+                
                 Picker(Constants.modePickerTitle, selection: $store.mode) {
                     Image(systemName: Constants.gridIconName)
                         .tag(PresentationMode.grid)

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratDetailView.swift
@@ -26,10 +26,24 @@ struct MandaratDetailView: View {
         VStack {
             switch store.mode {
             case .grid:
-                MandaratChartView(store: store.scope(state: \.mandaratChartFeatureState, action: \.mandaratChartFeatureAction))
+                MandaratChartView(store: store.scope(state: \.mandaratChartFeatureState, action: \.mandaratChartFeatureAction)) { subject in
+                    store.send(.view(.tapEditSubjectButton(subject)))
+                } onEditObjective: { objective in
+                    store.send(.view(.tapEditObjectiveButton(objective)))
+                } onEditActionIdea: { actionIdea in
+                    store.send(.view(.tapEditActionIdeaButton(actionIdea)))
+                }
+
                 
             case .list:
-                MandaratListView(store: store.scope(state: \.mandaratListFeatureState, action: \.mandaratListFeatureAction))
+                MandaratListView(store: store.scope(state: \.mandaratListFeatureState, action: \.mandaratListFeatureAction)) { subject in
+                    store.send(.view(.tapEditSubjectButton(subject)))
+                } onEditObjective: { objective in
+                    store.send(.view(.tapEditObjectiveButton(objective)))
+                } onEditActionIdea: { actionIdea in
+                    store.send(.view(.tapEditActionIdeaButton(actionIdea)))
+                }
+
             }
         }
         .navigationTitle(store.mandarat.title)
@@ -53,6 +67,9 @@ struct MandaratDetailView: View {
                 }
                 .pickerStyle(.segmented)
             }
+        }
+        .sheet(store: store.scope(state: \.$mandaratEditFeatureState, action: \.mandaratEditFeatureAction)) { editStore in
+            MandaratEditView(store: editStore)
         }
     }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
@@ -10,17 +10,45 @@ import ComposableArchitecture
 import MandaratDomain
 import DesignSystem
 
+private typealias StringLiterals = Mandamong.Strings
+
 struct MandaratListView: View {
+    private enum Constants {
+        static let editIconName: String = "pencil"
+    }
+    
     @Bindable var store: StoreOf<MandaratListFeature>
     
-    init(store: StoreOf<MandaratListFeature>) {
+    let onEditSubject: (Subject) -> Void
+    let onEditObjective: (Objective) -> Void
+    let onEditActionIdea: (ActionIdea) -> Void
+    
+    init(
+        store: StoreOf<MandaratListFeature>,
+        onEditSubject: @escaping (Subject) -> Void,
+        onEditObjective: @escaping (Objective) -> Void,
+        onEditActionIdea: @escaping (ActionIdea) -> Void
+    ) {
         self.store = store
+        self.onEditSubject = onEditSubject
+        self.onEditObjective = onEditObjective
+        self.onEditActionIdea = onEditActionIdea
     }
     
     var body: some View {
         List {
             Section(Mandamong.Strings.Mandarat.subject) {
                 cellLabel(store.mandarat.subject.content, completionRate: store.mandarat.completionRate)
+                    .contentShape(.rect)
+                    .onLongPressGesture { onEditSubject(store.mandarat.subject) }
+                    .swipeActions(edge: .leading) {
+                        Button {
+                            onEditSubject(store.mandarat.subject)
+                        } label: {
+                            Label(StringLiterals.Common.edit, systemImage: Constants.editIconName)
+                        }
+                        .tint(.blue)
+                    }
             }
 
             Section(Mandamong.Strings.Mandarat.objective) {
@@ -32,9 +60,27 @@ struct MandaratListView: View {
                                     .strikethrough(actionIdea.isCompleted)
                                     .foregroundStyle(actionIdea.isCompleted ? .mandamongSecondary : .mandamongPrimary)
                             }
+                            .onLongPressGesture { onEditActionIdea(actionIdea) }
+                            .swipeActions(edge: .leading) {
+                                Button {
+                                    onEditActionIdea(actionIdea)
+                                } label: {
+                                    Label(StringLiterals.Common.edit, systemImage: Constants.editIconName)
+                                }
+                                .tint(.blue)
+                            }
                         }
                     } label: {
                         cellLabel(objective.content, completionRate: objective.completionRate)
+                            .onLongPressGesture { onEditObjective(objective) }
+                            .swipeActions(edge: .leading) {
+                                Button {
+                                    onEditObjective(objective)
+                                } label: {
+                                    Label(StringLiterals.Common.edit, systemImage: Constants.editIconName)
+                                }
+                                .tint(.blue)
+                            }
                     }
                 }
             }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratDetail/MandaratList/MandaratListView.swift
@@ -58,5 +58,11 @@ struct MandaratListView: View {
 }
 
 #Preview {
-    MandaratListView(store: .init(initialState: MandaratListFeature.State.init(mandarat: .mock), reducer: { MandaratListFeature() }))
+    MandaratListView(store: .init(initialState: MandaratListFeature.State.init(mandarat: .mock), reducer: { MandaratListFeature() })) { _ in
+        ()
+    } onEditObjective: { _ in
+        ()
+    } onEditActionIdea: { _ in
+        ()
+    }
 }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratEdit/MandaratEditFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratEdit/MandaratEditFeature.swift
@@ -1,0 +1,103 @@
+//
+//  MandaratEditFeature.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/22/25.
+//
+
+import ComposableArchitecture
+import MandaratDomain
+
+@Reducer
+struct MandaratEditFeature {
+    /// 수정 대상 구분
+    enum EditTarget: Equatable {
+        case subject(id: Subject.ID, currentContent: String)
+        case objective(id: Objective.ID, currentContent: String)
+        case actionIdea(id: ActionIdea.ID, currentContent: String)
+    }
+    
+    /// 수정 단계
+    enum Step {
+        /// 수정 단계
+        case editing
+        /// Cascade Rule 적용 확인 단계
+        case confirmingCascade
+    }
+    
+    @ObservableState
+    struct State: Equatable {
+        let target: EditTarget
+        var content: String
+        var step: Step = .editing
+        
+        init(target: EditTarget) {
+            self.target = target
+            switch target {
+            case .subject(_, let content), .objective(_, let content), .actionIdea(_, let content):
+                self.content = content
+            }
+        }
+    }
+    
+    @CasePathable
+    enum Action: BindableAction {
+        enum ViewAction {
+            case tapCancelButton
+            case tapSaveButton
+            case tapConfirmCascadeOnlyButton
+            case tapConfirmCascadeWithChildrenButton
+        }
+        
+        enum DelegateAction {
+            case saveCompleted(target: EditTarget, newContent: String, cascade: Bool)
+        }
+        
+        case view(ViewAction)
+        case delegate(DelegateAction)
+        case binding(BindingAction<State>)
+    }
+    
+    @Dependency(\.dismiss) var dismiss
+    
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+        
+        Reduce { state, action in
+            switch action {
+            case .view(.tapCancelButton):
+                return .run { _ in await dismiss() }
+                
+            case .view(.tapSaveButton):
+                guard state.content.isEmpty == false else { return .none }
+                
+                switch state.target {
+                case .actionIdea:
+                    return .run { [content = state.content, target = state.target] send in
+                        await send(.delegate(.saveCompleted(target: target, newContent: content, cascade: false)))
+                        await dismiss()
+                    }
+                    
+                case .subject, .objective:
+                    state.step = .confirmingCascade
+                    return .none
+                }
+                
+            case .view(.tapConfirmCascadeOnlyButton):
+                return .run { [content = state.content, target = state.target] send in
+                    await send(.delegate(.saveCompleted(target: target, newContent: content, cascade: false)))
+                    await dismiss()
+                }
+                
+            case .view(.tapConfirmCascadeWithChildrenButton):
+                return .run { [content = state.content, target = state.target] send in
+                    await send(.delegate(.saveCompleted(target: target, newContent: content, cascade: true)))
+                    await dismiss()
+                }
+                
+            case .binding, .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratEdit/MandaratEditView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratEdit/MandaratEditView.swift
@@ -1,0 +1,94 @@
+//
+//  MandaratEditView.swift
+//  MandaratFeature
+//
+//  Created by SwainYun on 10/22/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import MandaratDomain
+import DesignSystem
+
+private typealias StringLiterals = Mandamong.Strings
+
+struct MandaratEditView: View {
+    @Bindable var store: StoreOf<MandaratEditFeature>
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                switch store.step {
+                case .editing:
+                    editingView
+                    
+                case .confirmingCascade:
+                    confirmingCascadeView
+                }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+        }
+    }
+    
+    private var editingView: some View {
+        Form {
+            Section("수정할 내용") {
+                TextField("내용 입력", text: $store.content, axis: .vertical)
+                    .lineLimit(3...)
+            }
+        }
+    }
+    
+    private var confirmingCascadeView: some View {
+        VStack(spacing: 20) {
+            Text("하위 요소도 함께 수정할까요?")
+            
+            Button {
+                store.send(.view(.tapConfirmCascadeWithChildrenButton))
+            } label: {
+                Text("하위 요소도 함께 수정")
+            }
+            .buttonStyle(.borderedProminent)
+            
+            Button {
+                store.send(.view(.tapConfirmCascadeOnlyButton))
+            } label: {
+                Text("이 요소만 수정")
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+    
+    private var navigationTitle: String {
+        switch store.target {
+        case .subject: "핵심 주제 수정"
+        case .objective: "목표 수정"
+        case .actionIdea: "행동 아이디어 수정"
+        }
+    }
+    
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if case .editing = store.step {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(StringLiterals.Common.cancel) {
+                    store.send(.view(.tapCancelButton))
+                }
+            }
+            
+            ToolbarItem(placement: .confirmationAction) {
+                Button(StringLiterals.Common.save) {
+                    store.send(.view(.tapSaveButton))
+                }
+                .disabled(store.content.isEmpty)
+            }
+        }
+    }
+}
+
+#Preview {
+    MandaratEditView(store: .init(initialState: MandaratEditFeature.State(target: .subject(id: 1, currentContent: "current content")), reducer: { MandaratEditFeature() }))
+}

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeFeature.swift
@@ -12,14 +12,18 @@ import MandaratDomain
 struct MandaratHomeFeature {
     @ObservableState
     struct State: Equatable {
-        var mandarats: IdentifiedArrayOf<Mandarat> = IdentifiedArray(uniqueElements: Mandarat.mocks)
+        var mandarats: IdentifiedArrayOf<Mandarat>
         var path: StackState<Path.State> = .init()
+        
+        init(mandarats: IdentifiedArrayOf<Mandarat> = .init(uniqueElements: Mandarat.mocks)) {
+            self.mandarats = mandarats
+        }
     }
     
     @CasePathable
     enum Action: BindableAction {
         enum ViewAction {
-            
+            case swipeToDelete(Mandarat.ID)
         }
         
         case view(ViewAction)
@@ -32,10 +36,19 @@ struct MandaratHomeFeature {
         
         Reduce { state, action in
             switch action {
+            case let .view(.swipeToDelete(id)):
+                state.mandarats.remove(id: id)
+                return .none
+                
             case .view:
                 return .none
                 
             case .binding:
+                return .none
+                
+            case let .path(.element(id: pathID, action: .mandaratDetailFeatureAction(.delegate(.deleteMandarat(mandaratID))))):
+                state.mandarats.remove(id: mandaratID)
+                state.path.pop(from: pathID)
                 return .none
                 
             case .path:

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeFeature.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeFeature.swift
@@ -51,6 +51,10 @@ struct MandaratHomeFeature {
                 state.path.pop(from: pathID)
                 return .none
                 
+            case let .path(.element(id: _, action: .mandaratDetailFeatureAction(.delegate(.didUpdateMandarat(updatedMandarat))))):
+                state.mandarats[id: updatedMandarat.id] = updatedMandarat
+                return .none
+                
             case .path:
                 return .none
             }

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
@@ -10,6 +10,8 @@ import MandaratDomain
 import ComposableArchitecture
 import DesignSystem
 
+private typealias StringLiterals = Mandamong.Strings
+
 public struct MandaratHomeView: View {
     private enum Constants {
         static let createIconName: String = "plus"
@@ -24,34 +26,39 @@ public struct MandaratHomeView: View {
     public var body: some View {
         NavigationStackStore(store.scope(state: \.path, action: \.path)) {
             ZStack(alignment: .bottomTrailing) {
-                GeometryReader { proxy in
-                    List {
-                        ForEach(store.mandarats) { mandarat in
-                            NavigationLink(state: MandaratHomeFeature.Path.State.mandaratDetailFeatureState(.init(mandarat: mandarat))) {
-                                cell(mandarat, width: proxy.size.width)
-                            }
-                            .listRowSeparator(.hidden)
-                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                Button(role: .destructive) {
-                                    store.send(.view(.swipeToDelete(mandarat.id)))
-                                } label: {
-                                    Label(Mandamong.Strings.Common.delete, systemImage: Constants.deleteIconName)
+                if store.mandarats.isEmpty {
+                    ContentUnavailableView {
+                        Text(StringLiterals.Mandarat.emptyMandaratsTitleMessage)
+                    } description: {
+                        Text(StringLiterals.Mandarat.emptyMandaratsDescriptionMessage)
+                    } actions: {
+                        createMandaratButton
+                    }
+
+                } else {
+                    GeometryReader { proxy in
+                        List {
+                            ForEach(store.mandarats) { mandarat in
+                                NavigationLink(state: MandaratHomeFeature.Path.State.mandaratDetailFeatureState(.init(mandarat: mandarat))) {
+                                    cell(mandarat, width: proxy.size.width)
+                                }
+                                .listRowSeparator(.hidden)
+                                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                    Button(role: .destructive) {
+                                        store.send(.view(.swipeToDelete(mandarat.id)))
+                                    } label: {
+                                        Label(StringLiterals.Common.delete, systemImage: Constants.deleteIconName)
+                                    }
                                 }
                             }
                         }
+                        .listStyle(.plain)
                     }
-                    .listStyle(.plain)
                 }
                 
-                Button {
-                    // TODO: 만다라트 생성 기능 추가
-                } label: {
-                    Image(systemName: Constants.createIconName)
-                }
-                .buttonStyle(.borderedProminent)
-                .padding()
+                createMandaratButton
             }
-            .navigationTitle(Mandamong.Strings.Mandarat.mandarat)
+            .navigationTitle(StringLiterals.Mandarat.mandarat)
         } destination: { store in
             switch store.state {
             case .mandaratDetailFeatureState:
@@ -95,6 +102,16 @@ private extension MandaratHomeView {
                 .fill(.mandamongBackground)
                 .shadow(color: .mandamongSecondary.opacity(Constants.cellBackgroundOpacity), radius: Constants.cellCornerRadius, y: 10)
         )
+    }
+    
+    var createMandaratButton: some View {
+        Button {
+            // TODO: 만다라트 생성 기능 추가
+        } label: {
+            Image(systemName: Constants.createIconName)
+        }
+        .buttonStyle(.borderedProminent)
+        .padding()
     }
 }
 

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
@@ -11,28 +11,42 @@ import ComposableArchitecture
 import DesignSystem
 
 public struct MandaratHomeView: View {
+    private enum Constants {
+        static let createIconName: String = "plus"
+        static let deleteIconName: String = "trash"
+        static let cellContentSpacing: CGFloat = 30
+        static let cellCornerRadius: CGFloat = 8
+        static let cellBackgroundOpacity: CGFloat = 0.4
+    }
+    
     let store: StoreOf<MandaratHomeFeature> = .init(initialState: MandaratHomeFeature.State()) { MandaratHomeFeature() }
     
     public var body: some View {
         NavigationStackStore(store.scope(state: \.path, action: \.path)) {
             ZStack(alignment: .bottomTrailing) {
                 GeometryReader { proxy in
-                    ScrollView(.vertical) {
-                        LazyVStack(spacing: 30) {
-                            ForEach(store.mandarats) { mandarat in
-                                NavigationLink(state: MandaratHomeFeature.Path.State.mandaratDetailFeatureState(.init(mandarat: mandarat))) {
-                                    cell(mandarat, width: proxy.size.width)
+                    List {
+                        ForEach(store.mandarats) { mandarat in
+                            NavigationLink(state: MandaratHomeFeature.Path.State.mandaratDetailFeatureState(.init(mandarat: mandarat))) {
+                                cell(mandarat, width: proxy.size.width)
+                            }
+                            .listRowSeparator(.hidden)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    store.send(.view(.swipeToDelete(mandarat.id)))
+                                } label: {
+                                    Label(Mandamong.Strings.Common.delete, systemImage: Constants.deleteIconName)
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
                     }
+                    .listStyle(.plain)
                 }
                 
                 Button {
                     // TODO: 만다라트 생성 기능 추가
                 } label: {
-                    Image(systemName: "plus")
+                    Image(systemName: Constants.createIconName)
                 }
                 .buttonStyle(.borderedProminent)
                 .padding()
@@ -54,7 +68,7 @@ private extension MandaratHomeView {
     @ViewBuilder
     func cell(_ mandarat: Mandarat, width: CGFloat) -> some View {
         HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Constants.cellContentSpacing) {
                 Text(mandarat.title)
                 
                 Text(mandarat.subject.content)
@@ -77,11 +91,10 @@ private extension MandaratHomeView {
         }
         .padding()
         .background(
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: Constants.cellCornerRadius)
                 .fill(.mandamongBackground)
-                .shadow(color: .mandamongSecondary.opacity(0.4), radius: 10, y: 10)
+                .shadow(color: .mandamongSecondary.opacity(Constants.cellBackgroundOpacity), radius: Constants.cellCornerRadius, y: 10)
         )
-        .padding(.horizontal)
     }
 }
 

--- a/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
+++ b/Projects/Mandarat/MandaratFeature/Sources/MandaratHome/MandaratHomeView.swift
@@ -16,7 +16,7 @@ public struct MandaratHomeView: View {
     private enum Constants {
         static let createIconName: String = "plus"
         static let deleteIconName: String = "trash"
-        static let cellContentSpacing: CGFloat = 30
+        static let cellContentSpacing: CGFloat = 4
         static let cellCornerRadius: CGFloat = 8
         static let cellBackgroundOpacity: CGFloat = 0.4
     }

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -18,6 +18,10 @@ extension Mandamong {
             public static let grid: String = "격자형"
             public static let list: String = "목록형"
             public static let delete: String = "삭제"
+            public static let cancel: String = "취소"
+            public static let save: String = "저장"
+            public static let next: String = "다음"
+            public static let edit: String = "수정"
         }
         
         /// 로그인 화면 관련 리터럴

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -17,6 +17,7 @@ extension Mandamong {
         public enum Common {
             public static let grid: String = "격자형"
             public static let list: String = "목록형"
+            public static let delete: String = "삭제"
         }
         
         /// 로그인 화면 관련 리터럴

--- a/Projects/Shared/DesignSystem/Sources/Mandamong.swift
+++ b/Projects/Shared/DesignSystem/Sources/Mandamong.swift
@@ -49,6 +49,8 @@ extension Mandamong {
             public static let subject: String = "핵심 주제"
             public static let objective: String = "세부 목표"
             public static let actionIdea: String = "행동 아이디어"
+            public static let emptyMandaratsTitleMessage: String = "아직 만다라트가 없어요."
+            public static let emptyMandaratsDescriptionMessage: String = "새로운 만다라트를 만들어 보세요."
         }
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
- 만다라트 홈 및 상세 화면의 UD 비즈니스 로직을 구현했습니다. (C-WIP)
- **Delete**: 홈 목록 스와이프 삭제 및 상세 화면 툴바 삭제 버튼 기능을 구현했습니다.
- **Update**: 상세 화면(그리드형, 목록형)에서 '길게 누르기' 또는 '옆으로 밀기'를 통해 만다라트 요소를 수정하는 기능을 구현했습니다.
- **Cascade Rule 설정**: 수정 시 하위 요소까지 연쇄 수정할지 묻는 확인 로직을 비즈니스 규칙에 맞게 추가했습니다.
- Data Sync: 상세 화면에서 수정/삭제된 내용이 홈 목록(상위 리듀서)에 동기화 되도록 하였습니다.
- **ErrorPage**: 홈 목록이 비어있을 때 `ContentUnavailableView`를 표시하도록 개선했습니다.

---

|    구현 내용    |   GIF / ScreenShot   |
| :-------------: | :----------: |
| Swipe Action Update | <img src = "https://github.com/user-attachments/assets/ccda7279-10f6-41d8-9f93-0a69eb974250" width ="300"> |
| Long Press Update | <img src = "https://github.com/user-attachments/assets/606e424e-ec0b-4e9e-95e9-df0743b02b61" width ="300"> |
| Deletion | <img src = "https://github.com/user-attachments/assets/124d5253-91bb-4a98-80a6-1b51decc27ed" width ="300"> |

## 💻 주요 코드 설명

### 수정 로직 분리
그리드 뷰와 목록 뷰에서 중복되는 '수정' 로직을 `MandaratEditFeature`라는 별도의 기능으로 추출해 캡슐화했습니다.
`DetailFeature`는 `@Presents`를 통해 이 기능을 Sheet로 띄워 사용하기만 하면 됩니다.

`MandaratEditFeature`는 '텍스트 입력'과 '검토 및 저장' 단계를 자체 `Step`상태로 관리하여 단일 책임을 갖도록 설계했습니다.

### View(자식) -> Feature(부모) 이벤트 위임
`MandaratChartView`와 `MandaratListView`는 '수정'로직을 직접 갖지 않습니다. 대신 상위 Feature로부터 클로저를 주입받아 이벤트 처리를 위임합니다.

## 👀 리뷰어에게 전달할 사항
* 비즈니스 규칙이 새로 정의됨에 따라 CRUD 요소 중, U와 D만 구현했습니다. 추후 C를 새로운 이슈로 등록하고 작업할 예정입니다. (R은 기존 코드로 구현 완료한 것으로 간주)
* `MandaratRepository` 등 Repository Layer가 아직 구현되지 않아, 임시로 유사한 동작을 수행하는 헬퍼 메서드 `updateMandaratElement`를 통해 만다라트 요소를 수정하도록 처리했습니다. 추후 리팩토링 대상에 포함합니다.

## 🔗 연결된 이슈
- Resolved: #48


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주제, 목표, 행동 아이디어를 길게 누르거나 스와이프하여 편집할 수 있습니다.
  * 편집 시 하위 항목에 변경사항을 적용할지 선택하는 옵션이 추가되었습니다.
  * 마다라트 항목을 스와이프 제스처로 삭제할 수 있습니다.
  * 마다라트가 없을 때 빈 상태 화면과 생성 버튼이 표시됩니다.

* **개선 사항**
  * 완료도 계산 로직이 업데이트되었습니다.
  * 새로운 UI 요소 및 문자열이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->